### PR TITLE
Adding afterChange function, InitialSlider and fixing a bug when using centre mode and not infinate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,35 @@ var SimpleSlider = React.createClass({
   }
 });
 ```
+
+|    Property    | Type |          Description          | Working |
+| -------------  | ---- |          -----------          | ------- |
+| className      | String |Additional class name for the inner slider div | Yes | 
+| adaptiveHeight | | | | 
+| arrows         | bool | Should we show Left and right nav arrows | Yes |
+| autoplay       | bool | Should the scroller auto scroll? | Yes |
+| autoplaySpeed  |  int | delay between each auto scoll. in ms | Yes |
+| centerMode     | bool | Should we centre to a single item? | Yes |
+| centerPadding  | | | |
+| cssEase        | | | | 
+| dots           |bool | Should we show the dots at the bottom of the gallery | Yes |
+| dotsClass      | string | Class applied to the dots if they are enabled | Yes | 
+| draggable      | bool | Is the gallery scrollable via dragging on desktop? | Yes |
+| easing         | string | | |
+| fade           | bool | | | 
+| focusOnSelect  | bool | | | 
+| infinite       | should the gallery wrap around it's contents | Yes |
+| initialSlide   | int | which item should be the first to be displayed | Yes (since pull req #17) | 
+| responsive     | | | |
+| rtl            | bool | | |
+| slide         | string |||
+| slidesToShow | int | Number of slides to be visible at a time | Yes |
+| slidesToScroll | int | Number of slides to scroll for each navigation item
+| speed | int |||
+| swipe | bool |||
+| swipeToSlide | bool |||
+| touchMove | bool |||
+| touchThreshold | int |||
+| variableWidth | bool |||
+| vertical | bool |||
+| afterChange | function | callback function called when the current index changes | Yes (since pull req #17) |

--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -136,7 +136,9 @@ var CenterMode = React.createClass({
       infinite: true,
       centerPadding: '60px',
       slidesToShow: 3,
-      speed: 500,
+      speed: 500,   afterChange:function(a){
+        alert("Slider Changed to :"+a);
+      }
     }
     return (
       <div>

--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -157,6 +157,36 @@ var CenterMode = React.createClass({
   }
 });
 
+var CenterModeWithInitial = React.createClass({
+  render: function () {
+    var settings = {
+      className: 'center',
+      centerMode: true,
+      infinite: false,
+      centerPadding: '60px',
+      slidesToShow: 3,
+      initialSlide: 3,
+      speed: 500,   afterChange:function(index){
+        console.log('%c Slider Changed to:'+index, 'background: #222; color: #bada55');
+      }
+    }
+    return (
+      <div>
+        <h2>Center Mode With InitalSlideSet</h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+          <div><h3>5</h3></div>
+          <div><h3>6</h3></div>
+        </Slider>
+      </div>
+    );
+  }
+});
+
+
 var AutoPlay = React.createClass({
   render: function () {
     var settings = {
@@ -254,11 +284,12 @@ var App = React.createClass({
     //need to add variable width and center mode demo
     return (
       <div className='content'>
-        <SingleItem />
+          <SingleItem />
         <MultipleItems />
         <Responsive />
         <UnevenSets />
         <CenterMode />
+        <CenterModeWithInitial />
         <AutoPlay />
         <VariableWidth />
         <AdaptiveHeight />

--- a/lib/default-props.js
+++ b/lib/default-props.js
@@ -30,7 +30,8 @@ var defaultProps = {
     // useCSS: true,
     variableWidth: false,
     vertical: false,
-    // waitForAnimate: true
+    // waitForAnimate: true,
+    afterChange: null
 };
 
 module.exports = defaultProps;

--- a/lib/inner-slider.jsx
+++ b/lib/inner-slider.jsx
@@ -54,7 +54,7 @@ var Slider = React.createClass({
     var count = React.Children.count(this.props.children);
     React.Children.forEach(this.props.children, function (child, index) {
       var infiniteCount;
-
+      console.log("Rendering Slide:",index);
       slides.push(cloneWithProps(child, {
         key: index,
         'data-index': index,

--- a/lib/inner-slider.jsx
+++ b/lib/inner-slider.jsx
@@ -54,7 +54,6 @@ var Slider = React.createClass({
     var count = React.Children.count(this.props.children);
     React.Children.forEach(this.props.children, function (child, index) {
       var infiniteCount;
-      console.log("Rendering Slide:",index);
       slides.push(cloneWithProps(child, {
         key: index,
         'data-index': index,
@@ -112,9 +111,19 @@ var Slider = React.createClass({
           prevClasses['slick-disabled'] = true;
           prevHandler = null;
         }
-        if (this.state.currentSlide >= (this.state.slideCount - this.props.slidesToShow)) {
-          nextClasses['slick-disabled'] = true;
-          nextHandler = null;
+
+        if (this.props.centerMode && !this.props.infinite)
+        {
+         if (this.state.currentSlide >= (this.state.slideCount - 1)) {
+            nextClasses['slick-disabled'] = true;
+            nextHandler = null;
+          }
+        }else
+        {
+          if (this.state.currentSlide >= (this.state.slideCount - this.props.slidesToShow)) {
+            nextClasses['slick-disabled'] = true;
+            nextHandler = null;
+          }
         }
       }
 

--- a/lib/mixins/helpers.js
+++ b/lib/mixins/helpers.js
@@ -15,10 +15,12 @@ var helpers = {
       slideWidth: slideWidth,
       listWidth: listWidth,
       trackWidth: trackWidth,
-      currentSlide: 0
+      currentSlide: this.props.initialSlide
+    
+    
     }, function () {
       // getCSS function needs previously set state
-      var trackStyle = this.getCSS(this.getLeft(0));
+      var trackStyle = this.getCSS(this.getLeft(this.state.currentSlide));
       this.setState({trackStyle: trackStyle});
     });
   },

--- a/lib/mixins/helpers.js
+++ b/lib/mixins/helpers.js
@@ -194,6 +194,11 @@ var helpers = {
     if (this.props.infinite === false) {
       targetLeft = currentLeft;
     }
+
+    if(this.props.afterChange!==null){
+      this.props.afterChange(currentSlide);
+    }
+
     this.setState({
       animating: true,
       currentSlide: currentSlide,


### PR DESCRIPTION
Hey,
I've implemented afterChange which is a property passing in via settings which is expected to be a function with a single parameter of the index which we have just navigated too.
I've also added this to the demo page, but it simply prints to the console with highlighted colours in chrome.

I've implemented the Initial Slide property (as requested on https://github.com/akiran/react-slick/issues/15)

There was also a bug with the Centre slider when infinite wasn't enabled, and you couldn't navigate to the final slide.

Cheers
Stephen Roberts