### PR TITLE
Change this.props.initialSlide to props.initialSlide in initialize

### DIFF
--- a/lib/mixins/helpers.js
+++ b/lib/mixins/helpers.js
@@ -15,7 +15,7 @@ var helpers = {
       slideWidth: slideWidth,
       listWidth: listWidth,
       trackWidth: trackWidth,
-      currentSlide: this.props.initialSlide
+      currentSlide: props.initialSlide
     
     
     }, function () {


### PR DESCRIPTION
props is passed into initialize and initialize is not being bound to the places it's called so using props instead of this.props gives the correct initialslide for the current props being passed in.

This causes a problem of if you're passing in initialSlide, and whenever a state changes out of the component, the component will be one slide behind because it was using the previously set this.props.initialSlide instead of the current props.initialSlide passed in.