### PR TITLE
Work with React 0.12 and 0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "slick-carousel": "^1.3.15"
   },
   "peerDependencies": {
-    "react": ">0.12.*"
+    "react": ">=0.12.*"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
This `>` should have been a `>=` to permit version 0.12