### PR TITLE
Apply a -webkit-transition for the -webkit-transform.

### DIFF
--- a/lib/mixins/helpers.js
+++ b/lib/mixins/helpers.js
@@ -85,7 +85,7 @@ var helpers = {
   },
   getAnimateCSS: function (targetLeft) {
     var style = this.getCSS(targetLeft);
-    style.WebkitTransition = 'transform ' + this.props.speed + 'ms ' + this.props.cssEase;
+    style.WebkitTransition = '-webkit-transform ' + this.props.speed + 'ms ' + this.props.cssEase;
     style.transition = 'transform ' + this.props.speed + 'ms ' + this.props.cssEase;
     return style;
   },
@@ -104,6 +104,8 @@ var helpers = {
       width: trackWidth,
       WebkitTransform: 'translate3d(' + targetLeft + 'px, 0px, 0px)',
       transform: 'translate3d(' + targetLeft + 'px, 0px, 0px)',
+      transition: '',
+      WebkitTransition: ''
     };
     
     return style;


### PR DESCRIPTION
Otherwise iOS 8 Safari is transitioning `transform`, but applying `-webkit-transform`
(and ignoring `transform`).