### PR TITLE
fix logic when infinite = false

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -98,13 +98,17 @@ var helpers = {
 
     targetSlide = index;
     if (targetSlide < 0) {
-      if (this.state.slideCount % this.props.slidesToScroll !== 0) {
+      if(this.props.infinite === false) {
+        currentSlide = 0;
+      } else if (this.state.slideCount % this.props.slidesToScroll !== 0) {
         currentSlide = this.state.slideCount - (this.state.slideCount % this.props.slidesToScroll);
       } else {
         currentSlide = this.state.slideCount + targetSlide;
       }
     } else if (targetSlide >= this.state.slideCount) {
-      if (this.state.slideCount % this.props.slidesToScroll !== 0) {
+      if(this.props.infinite === false) {
+        currentSlide = this.state.slideCount - this.props.slidesToShow;
+      } else if (this.state.slideCount % this.props.slidesToScroll !== 0) {
         currentSlide = 0;
       } else {
         currentSlide = targetSlide - this.state.slideCount;


### PR DESCRIPTION
The current version will still loop from one end of the slideshow to the other, even when the `infinite` property is set to `false`.

This pull request fixes that :boom: 