### PR TITLE
add support for 'unslick' responsive breakpoint setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ var SimpleSlider = React.createClass({
 | focusOnSelect  | bool | | | 
 | infinite       | should the gallery wrap around it's contents | Yes |
 | initialSlide   | int | which item should be the first to be displayed | Yes (since pull req #17) | 
-| responsive     | array | Array of objects in the form of `{ breakpoint: int, settings: { ... } }` The breakpoint _int_ is the `maxWidth` so the settings will be applied when resolution is below this value. Breakpoints in the array should be ordered from smalles to greatest. Example: `[ { breakpoint: 768, settings: { slidesToShow: 3 } }, { breakpoint: 1024, settings: { slidesToShow: 5 } } ]`| Yes |
+| responsive     | array | Array of objects in the form of `{ breakpoint: int, settings: { ... } }` The breakpoint _int_ is the `maxWidth` so the settings will be applied when resolution is below this value. Breakpoints in the array should be ordered from smalles to greatest. Use 'unslick' in place of the settings object to disable rendering the carousel at that breakpoint. Example: `[ { breakpoint: 768, settings: { slidesToShow: 3 } }, { breakpoint: 1024, settings: { slidesToShow: 5 } }, { breakpoint: 100000, settings: 'unslick' } ]`| Yes |
 | rtl            | bool | | |
 | slide         | string |||
 | slidesToShow | int | Number of slides to be visible at a time | Yes |

--- a/src/slider.jsx
+++ b/src/slider.jsx
@@ -43,15 +43,22 @@ var Slider = React.createClass({
     var newProps;
     if (this.state.breakpoint) {
       newProps = this.props.responsive.filter(resp => resp.breakpoint === this.state.breakpoint);
-      settings = assign({}, this.props, newProps[0].settings);
+      settings = newProps[0].settings === 'unslick' ? 'unslick' : _assign({}, this.props, newProps[0].settings);
     } else {
       settings = this.props;
     }
-    return (
-      <InnerSlider {...settings}>
-        {this.props.children}
-      </InnerSlider>
-    );
+    if (settings === 'unslick') {
+      // if 'unslick' responsive breakpoint setting used, just return the <Slider> tag nested HTML
+      return (
+        <div>{this.props.children}</div>
+      );
+    } else {
+      return (
+        <InnerSlider {...settings}>
+          {this.props.children}
+        </InnerSlider>
+      );
+    }
   }
 });
 


### PR DESCRIPTION
- porting this feature from the original slick carousel
- setting disables the slick carousel for the selected breakpoint (nested HTML not modified/slicked)
- responsive setting section of README updated with an example usage