### PR TITLE
Removed "dist" directory from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@ TODO.md
 test
 testlib
 docs
-dist
 src
 bower.json
 gulpfile.js


### PR DESCRIPTION
Since people may prefer to add compiled files in script tags instead of using something like browserify/webpack.

Relates to #76 

