### PR TITLE
fix autoPlayTimer not cleared after component unmounted

### DIFF
--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -47,6 +47,9 @@ export var InnerSlider = React.createClass({
   },
   componentWillUnmount: function () {
     window.removeEventListener('resize', this.onWindowResized);
+    if (this.state.autoPlayTimer) {
+      window.clearTimeout(this.state.autoPlayTimer);
+    }
   },
   componentDidUpdate: function () {
     this.adaptHeight();


### PR DESCRIPTION
While using react-slick in my application, this warning message occurred periodically:

`Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op.`

Seems like it is resulted from an uncleared timer, `autoPlayTimer`, while using the `autoplay` feature, and adding the `window.clearTimer` in `componentWillUnMount` fixes the problem.