### PR TITLE
Slider did not update current slide to initialSlide prop on update

### DIFF
--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -356,6 +356,54 @@ var Fade = React.createClass({
   }
 });
 
+var ExternalControl = React.createClass({
+  getInitialState: function() {
+    return {
+      initialSlide: 1 
+    }
+  },
+
+  handleClick: function(event) {
+    event.preventDefault();
+
+    this.setState({
+      initialSlide: 2
+    });
+  },
+
+  render: function () {
+    var settings = {
+      dots: false,
+      slidesToShow: 1,
+      slidesToScroll: 1,
+      initialSlide: this.state.initialSlide,
+      beforeChange: function (currentSlide, nextSlide) {
+        console.log('before change', currentSlide, nextSlide);
+      },
+      afterChange: function (currentSlide) {
+        console.log('after change', currentSlide);
+      }
+    };
+    return (
+      <div>
+        <h2>External Control</h2>
+        Control your slider externally by applying a parent state variables as props to a slider instance.
+        <br />
+        <br />
+        <button onClick={this.handleClick}>Click to go to slide 3</button> 
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+          <div><h3>5</h3></div>
+          <div><h3>6</h3></div>
+        </Slider>
+      </div>
+    );
+  }
+});
+
 var App = React.createClass({
   render: function () {
     //need to add variable width and center mode demo
@@ -372,6 +420,7 @@ var App = React.createClass({
         <AdaptiveHeight />
         <LazyLoad />
         <Fade />
+        <ExternalControl />
       </div>
     );
   }

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -58,6 +58,9 @@ var helpers = {
       var trackStyle = getTrackCSS(assign({left: targetLeft}, props, this.state));
 
       this.setState({trackStyle: trackStyle});
+
+      // Animate slider to initial slide passed as props 
+      this.slideHandler(props.initialSlide);
     });
   },
   getWidth: function getWidth(elem) {


### PR DESCRIPTION
External control methods were left out of the port due to their anti-pattern nature of parent updating state.  There have been several requests for the ability to update the current slide externally and the solution posted has always been to update the initialSlide prop.  Unfortunately the current update method does not use this to update the current index.  I have added a slideHandler method using the initialSlide index as the argument to facilitate an animated update of the slider.

I have also added a demo as it is a recurring question in issues.