### PR TITLE
Resolve unmounted state

### DIFF
--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -50,6 +50,9 @@ export var InnerSlider = React.createClass({
     if (this.state.autoPlayTimer) {
       window.clearTimeout(this.state.autoPlayTimer);
     }
+    this.setState({
+      mounted: false
+    });
   },
   componentWillReceiveProps: function(nextProps) {
     this.update(nextProps);

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -79,6 +79,10 @@ var helpers = {
     var targetLeft, currentLeft;
     var callback;
 
+    if (!this.state.mounted) {
+      return;
+    }
+
     if (this.state.animating === true || this.state.currentSlide === index) {
       return;
     }
@@ -248,9 +252,7 @@ var helpers = {
   },
   autoPlay: function () {
     var play = () => {
-      if (this.state.mounted) {
-        this.slideHandler(this.state.currentSlide + this.props.slidesToScroll);
-      }
+      this.slideHandler(this.state.currentSlide + this.props.slidesToScroll);
     };
     if (this.props.autoplay) {
       window.clearTimeout(this.state.autoPlayTimer);

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -251,15 +251,15 @@ var helpers = {
     return 'vertical';
   },
   autoPlay: function () {
-    var play = () => {
-      this.slideHandler(this.state.currentSlide + this.props.slidesToScroll);
-    };
     if (this.props.autoplay) {
       window.clearTimeout(this.state.autoPlayTimer);
       this.setState({
-        autoPlayTimer: window.setTimeout(play, this.props.autoplaySpeed)
+        autoPlayTimer: window.setTimeout(this.playNext, this.props.autoplaySpeed)
       });
     }
+  },
+  playNext: function () {
+    this.slideHandler(this.state.currentSlide + this.props.slidesToScroll);
   }
 };
 


### PR DESCRIPTION
Set unmounted state for any left over timers.

Currently, we manually track it's mounted state. However, it doesn't actually track when it is unmounted.  This may lead to an actual issue. More importantly, it leads to log spam when the component is unmounted.

```
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op.
```

Unmounting is fairly popular for those of using `react-router` / etc, so it's nice to clean it up.

I don't exactly understand why we're not simply using the `isMounted` hook, but it was changed for 21134ae aka https://github.com/akiran/react-slick/pull/63/files#diff-3f43ed4258c814c46d337afc1a320ae2L252 .


----
If the diff seems big, only 7fd9a08 is needed.  The others bits are just cleanup.  Sadly, the 