### PR TITLE
Very simple implementation for waitForAnimate property

### DIFF
--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -22,6 +22,7 @@ var SingleItem = React.createClass({
       speed: 500,
       slidesToShow: 1,
       slidesToScroll: 1,
+      waitForAnimate: false,
       beforeChange: function (currentSlide, nextSlide) {
         console.log('before change', currentSlide, nextSlide);
       },

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -31,7 +31,7 @@ var defaultProps = {
     useCSS: true,
     variableWidth: false,
     vertical: false,
-    // waitForAnimate: true,
+    waitForAnimate: true,
     afterChange: null,
     beforeChange: null,
     edgeEvent: null,

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -79,6 +79,10 @@ var helpers = {
     var targetLeft, currentLeft;
     var callback;
 
+    if (this.props.waitForAnimate && this.state.animating) {
+	return;
+    }
+
     if (this.state.currentSlide === index) {
       return;
     }


### PR DESCRIPTION
I need this functionality, which was removed in https://github.com/akiran/react-slick/commit/f56590a2c4e5d74a24617b2a233262babc010ad1

Reasons:
-  In some cases it's better for usability to have the slide not change before animation has been finished

- There's an issue with with react-slick; if user keeps clicking next/prev arrows in infinite scrolling slider, before animation has finished and animation duration is reasonably hight (say 500 ms),  the slider will end up with empty items. This is one workaround.

- The change was introduced to fix https://github.com/akiran/react-slick/issues/140 but the issue is still open.

However, I'm not sure if using waitForAnimate is the correct property to use but it's a start and seems to work.

