### PR TITLE
fix for centerMode warping #72

### DIFF
--- a/src/track.jsx
+++ b/src/track.jsx
@@ -18,7 +18,7 @@ var getSlideClasses = (spec) => {
   slickCloned = (index < 0) || (index >= spec.slideCount);
   if (spec.centerMode) {
     centerOffset = Math.floor(spec.slidesToShow / 2);
-    slickCenter = (spec.currentSlide === index);
+    slickCenter = (index - spec.currentSlide) % spec.slideCount === 0;
     if ((index > spec.currentSlide - centerOffset - 1) && (index <= spec.currentSlide + centerOffset)) {
       slickActive = true;
     }


### PR DESCRIPTION
took @vramana's approach.

now the center slide and all of its clones receive the 'slick-center' class.