### PR TITLE
Fixes the beforeChange / afterChange when fade = true

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -110,7 +110,7 @@ var helpers = {
           animating: false
         });
         if (this.props.afterChange) {
-          this.props.afterChange(currentSlide);
+          this.props.afterChange(targetSlide);
         }
         ReactTransitionEvents.removeEndEventListener(ReactDOM.findDOMNode(this.refs.track).children[currentSlide], callback);
       };
@@ -123,7 +123,7 @@ var helpers = {
       });
 
       if (this.props.beforeChange) {
-        this.props.beforeChange(this.state.currentSlide, currentSlide);
+        this.props.beforeChange(this.state.currentSlide, targetSlide);
       }
 
       this.autoPlay();


### PR DESCRIPTION
beforeChange / afterChange are bugged when fade is enabled (values are off), using targetSlide fixes that.