### PR TITLE
Fixing issue where current slide would go past the slidecount

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -220,7 +220,7 @@ var helpers = {
 
       this.setState({
         animating: true,
-        currentSlide: targetSlide,
+        currentSlide: currentSlide,
         trackStyle: getTrackAnimateCSS(assign({left: targetLeft}, this.props, this.state))
       }, function () {
         ReactTransitionEvents.addEndEventListener(ReactDOM.findDOMNode(this.refs.track), callback);


### PR DESCRIPTION
Seems like if autoplay is on and infinite is false the current slide will continue to increment. This causes a problem because the arrows will reflect that currentSlide meaning you will have to click the arrow until you reach the last slide.