### PR TITLE
Set z-index to move up current slide to top

### DIFF
--- a/src/track.jsx
+++ b/src/track.jsx
@@ -42,7 +42,13 @@ var getSlideStyle = function (spec) {
   if (spec.fade) {
     style.position = 'relative';
     style.left = -spec.index * spec.slideWidth;
-    style.opacity = (spec.currentSlide === spec.index) ? 1 : 0;
+    if (spec.currentSlide === spec.index) {
+      style.opacity = 1;
+      style.zIndex = 999;
+    } else {
+      style.opacity = 0;
+      style.zIndex = 998;
+    }
     style.transition = 'opacity ' + spec.speed + 'ms ' + spec.cssEase;
     style.WebkitTransition = 'opacity ' + spec.speed + 'ms ' + spec.cssEase;
   }


### PR DESCRIPTION
This PR fixes an issue on Fade type.
When slides contain clickable contents, I can't click a content of the current slide. What I can click is always **last slide**.

**Issue**: Can't click a content of current slide
**Fix**: Set `z-index` to slides

Please notice that the solution was brought from original slick library.