### PR TITLE
matching default functionality to slick

### DIFF
--- a/src/dots.jsx
+++ b/src/dots.jsx
@@ -43,7 +43,7 @@ export var Dots = React.createClass({
 
       return (
         <li key={i} className={className}>
-          <button onClick={this.clickHandler.bind(this, dotOptions)}>{i}</button>
+          <button onClick={this.clickHandler.bind(this, dotOptions)}>{i + 1}</button>
         </li>
       );
     });


### PR DESCRIPTION
You took my attention to these lines in my last PR: https://github.com/kenwheeler/slick/blob/master/slick/slick.js#L54-L56

and I noticed this time around that the default for the dots content is actually { i + 1 } instead of { i }. So this basic change actually matches the default dot content for slick.

Here's a screenshot of the content from the first dot on slicks webpage.

<img width="1002" alt="screen shot 2016-02-21 at 7 05 06 pm" src="https://cloud.githubusercontent.com/assets/1869524/13208472/470addec-d8ce-11e5-8fd1-dcfacb3df82b.png">

This does, however, affect backwards compatibility. How would you like to proceed?

Also, I'm working on the customPaging option in a separate branch.