### PR TITLE
Change this.props.children.length to use React.Children.count() instead.

### DIFF
--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -27,7 +27,7 @@ export var InnerSlider = React.createClass({
       mounted: true
     });
     var lazyLoadedList = [];
-    for (var i = 0; i < this.props.children.length; i++) {
+    for (var i = 0; i < React.Children.count(this.props.children); i++) {
       if (i >= this.state.currentSlide && i < this.state.currentSlide + this.props.slidesToShow) {
         lazyLoadedList.push(i);
       }


### PR DESCRIPTION
> Warning message "Iterable.length has been deprecated, use iterable.size or iterable.count()" when using ImmutableJS list as items

When using a immutable collection with react-slick you will receive the above error message. This pr fixes the issue by changing the collection measurement from length the to use the React.Children.Count.

P.S. This is my very first pull request so please let me know if I need to change anything.