### PR TITLE
add slick-arrow class to prev/next buttons as per slick-carousel

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./lib",
   "scripts": {
     "start": "gulp server",
+    "postinstall": "babel ./src --out-dir ./lib",
     "prepublish": "babel ./src --out-dir ./lib && gulp dist",
     "test": "karma start --single-run"
   },

--- a/src/arrows.jsx
+++ b/src/arrows.jsx
@@ -10,7 +10,7 @@ export var PrevArrow = React.createClass({
     this.props.clickHandler(options, e);
   },
   render: function () {
-    var prevClasses = {'slick-prev': true};
+    var prevClasses = {'slick-arrow': true, 'slick-prev': true};
     var prevHandler = this.clickHandler.bind(this, {message: 'previous'});
 
     if (!this.props.infinite && (this.props.currentSlide === 0 || this.props.slideCount <= this.props.slidesToShow)) {
@@ -44,7 +44,7 @@ export var NextArrow = React.createClass({
     this.props.clickHandler(options, e);
   },
   render: function () {
-    var nextClasses = {'slick-next': true};
+    var nextClasses = {'slick-arrow': true, 'slick-next': true};
     var nextHandler = this.clickHandler.bind(this, {message: 'next'});
 
     if (!this.props.infinite) {


### PR DESCRIPTION
These classes are on slick-carousel prev/next buttons, so they should be on react-slick ones, right?