### PR TITLE
If the slider receives new props with fewer children than before and …

### DIFF
--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -60,6 +60,12 @@ export var InnerSlider = React.createClass({
     }
   },
   componentWillReceiveProps: function(nextProps) {
+    if (this.state.currentSlide >= nextProps.children.length) {
+      this.setState({
+        currentSlide: nextProps.children.length - nextProps.slidesToShow
+      });
+    }
+
     if (this.props.slickGoTo != nextProps.slickGoTo) {
       this.changeSlide({
           message: 'index',

--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -60,16 +60,16 @@ export var InnerSlider = React.createClass({
     }
   },
   componentWillReceiveProps: function(nextProps) {
-    if (this.state.currentSlide >= nextProps.children.length) {
-      this.setState({
-        currentSlide: nextProps.children.length - nextProps.slidesToShow
-      });
-    }
-
     if (this.props.slickGoTo != nextProps.slickGoTo) {
       this.changeSlide({
           message: 'index',
           index: nextProps.slickGoTo,
+          currentSlide: this.state.currentSlide
+      });
+    } else if (this.state.currentSlide >= nextProps.children.length) {
+      this.changeSlide({
+          message: 'index',
+          index: nextProps.children.length - nextProps.slidesToShow,
           currentSlide: this.state.currentSlide
       });
     } else {


### PR DESCRIPTION
…the current slide index is now greater than the number of children, reset the current slide index to the start of the final page.

Fixes #267