### PR TITLE
Keep original keys for slides

### DIFF
--- a/src/track.jsx
+++ b/src/track.jsx
@@ -50,6 +50,11 @@ var getSlideStyle = function (spec) {
   return style;
 };
 
+var getKey = (child, fallbackKey) => {
+    // key could be a zero
+    return (child.key === null || child.key === undefined) ? fallbackKey : child.key;
+};
+
 var renderSlides = (spec) => {
   var key;
   var slides = [];
@@ -75,7 +80,7 @@ var renderSlides = (spec) => {
     }
 
     slides.push(React.cloneElement(child, {
-      key: index,
+      key: getKey(child, index),
       'data-index': index,
       className: cssClasses,
       style: assign({}, child.props.style || {}, childStyle)
@@ -88,7 +93,7 @@ var renderSlides = (spec) => {
       if (index >= (count - infiniteCount)) {
         key = -(count - index);
         preCloneSlides.push(React.cloneElement(child, {
-          key: key,
+          key: getKey(child, key),
           'data-index': key,
           className: cssClasses,
           style: assign({}, child.props.style || {}, childStyle)
@@ -98,7 +103,7 @@ var renderSlides = (spec) => {
       if (index < infiniteCount) {
         key = count + index;
         postCloneSlides.push(React.cloneElement(child, {
-          key: key,
+          key: getKey(child, key),
           'data-index': key,
           className: cssClasses,
           style: assign({}, child.props.style || {}, childStyle)


### PR DESCRIPTION
Fix for #279 
Skip auto-generated keys for slides if key already exist.
