### PR TITLE
update arrows to use React.cloneElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "slick-carousel": "^1.5.5"
   },
   "peerDependencies": {
-    "react": "^0.13.0 || ^0.14.0"
+    "react": "^0.13.0 || ^0.14.0 || ^15.0.0"
   },
   "npmName": "react-slick",
   "npmFileMap": [

--- a/src/arrows.jsx
+++ b/src/arrows.jsx
@@ -28,7 +28,7 @@ export var PrevArrow = React.createClass({
     var prevArrow;
 
     if (this.props.prevArrow) {
-      prevArrow = <this.props.prevArrow {...prevArrowProps} />;
+      prevArrow = React.cloneElement(this.props.prevArrow, prevArrowProps);
     } else {
       prevArrow = <button key='0' type='button' {...prevArrowProps}> Previous</button>;
     }
@@ -76,7 +76,7 @@ export var NextArrow = React.createClass({
     var nextArrow;
 
     if (this.props.nextArrow) {
-      nextArrow = <this.props.nextArrow {...nextArrowProps} />;
+      nextArrow = React.cloneElement(this.props.nextArrow, nextArrowProps);
     } else {
       nextArrow = <button key='1' type='button' {...nextArrowProps}> Next</button>;
     }


### PR DESCRIPTION
I updated arrow functions to use React.cloneElement so that you can pass in an already constructed element as well.