### PR TITLE
Fix breakage when re-rendering with different children

### DIFF
--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -61,7 +61,7 @@ export var InnerSlider = React.createClass({
   },
   componentWillReceiveProps: function(nextProps) {
     if (this.props.slickGoTo !== nextProps.slickGoTo
-      || this.props.children[0].key !== nextProps.children[0].key) {
+      || (this.props.children && this.props.children[0].key !== nextProps.children[0].key)) {
       this.changeSlide({
           message: 'index',
           index: nextProps.slickGoTo,

--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -60,11 +60,12 @@ export var InnerSlider = React.createClass({
     }
   },
   componentWillReceiveProps: function(nextProps) {
-    if (this.props.slickGoTo != nextProps.slickGoTo) {
+    if (this.props.slickGoTo !== nextProps.slickGoTo
+      || this.props.children[0].key !== nextProps.children[0].key) {
       this.changeSlide({
-          message: 'index',
-          index: nextProps.slickGoTo,
-          currentSlide: this.state.currentSlide
+        message: 'index',
+        index: nextProps.slickGoTo,
+        currentSlide: this.state.currentSlide
       });
     } else {
       this.update(nextProps);

--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -63,9 +63,9 @@ export var InnerSlider = React.createClass({
     if (this.props.slickGoTo !== nextProps.slickGoTo
       || this.props.children[0].key !== nextProps.children[0].key) {
       this.changeSlide({
-        message: 'index',
-        index: nextProps.slickGoTo,
-        currentSlide: this.state.currentSlide
+          message: 'index',
+          index: nextProps.slickGoTo,
+          currentSlide: this.state.currentSlide
       });
     } else {
       this.update(nextProps);


### PR DESCRIPTION
This addresses the slider disappearing and becoming unusable, relating to changing the children (slides). It fixes #297, and could also be the solution for #267, #278, and #295.