### PR TITLE
Replace babel with babel-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "devDependencies": {
     "autoprefixer-core": "^6.0.1",
-    "babel": "^6.5.2",
+    "babel-cli": "^6.10.1",
     "babel-core": "^6.9.0",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
When running npm install:

```
You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.

    npm uninstall babel
    npm install babel-cli

See http://babeljs.io/docs/usage/cli/ for setup instructions.
```