### PR TITLE
Add babel-preset-react-hmre dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-react-hmre": "^1.1.1",
     "css-loader": "^0.23.1",
     "deepmerge": "^0.2.10",
     "del": "^2.2.0",


### PR DESCRIPTION
Fixes:

```
ERROR in ../react-slick/lib/index.js
Module build failed: Error: Couldn't find preset "react-hmre" relative to directory "/Users/yn5/stuff/web/puha/react-slick/lib"
    at /Users/yn5/stuff/web/puha/puhastudio-ern/node_modules/babel-core/lib/transformation/file/options/option-manager.js:372:17
    at Array.map (native)
    at OptionManager.resolvePresets (/Users/yn5/stuff/web/puha/puhastudio-ern/node_modules/babel-core/lib/transformation/file/options/option-manager.js:364:20)
    at OptionManager.mergePresets (/Users/yn5/stuff/web/puha/puhastudio-ern/node_modules/babel-core/lib/transformation/file/options/option-manager.js:348:10)
    at OptionManager.mergeOptions (/Users/yn5/stuff/web/puha/puhastudio-ern/node_modules/babel-core/lib/transformation/file/options/option-manager.js:307:14)
    at OptionManager.init (/Users/yn5/stuff/web/puha/puhastudio-ern/node_modules/babel-core/lib/transformation/file/options/option-manager.js:465:10)
    at File.initOptions (/Users/yn5/stuff/web/puha/puhastudio-ern/node_modules/babel-core/lib/transformation/file/index.js:194:75)
    at new File (/Users/yn5/stuff/web/puha/puhastudio-ern/node_modules/babel-core/lib/transformation/file/index.js:123:22)
    at Pipeline.transform (/Users/yn5/stuff/web/puha/puhastudio-ern/node_modules/babel-core/lib/transformation/pipeline.js:45:16)
    at transpile (/Users/yn5/stuff/web/puha/puhastudio-ern/node_modules/babel-loader/index.js:14:22)
 @ ./shared/components/Template/Text.js 32:18-40
```