### PR TITLE
dots: true should always show dots, regardless of number of images

### DIFF
--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -98,7 +98,7 @@ export var InnerSlider = React.createClass({
 
     var dots;
 
-    if (this.props.dots === true && this.state.slideCount > this.props.slidesToShow) {
+    if (this.props.dots === true && this.state.slideCount >= this.props.slidesToShow) {
       var dotProps = {
         dotsClass: this.props.dotsClass,
         slideCount: this.state.slideCount,


### PR DESCRIPTION
fixes #321 

Note this would mean hiding `:only-child` for people who _don't_ want a single dot to be displayed