### PR TITLE
pass through 'slickActive' prop to slide

### DIFF
--- a/src/track.jsx
+++ b/src/track.jsx
@@ -71,6 +71,7 @@ var renderSlides = (spec) => {
     }
     var childStyle = getSlideStyle(assign({}, spec, {index: index}));
     var slickClasses = getSlideClasses(assign({index: index}, spec));
+    var slickActive = slickClasses.indexOf('slick-active') > -1;
     var cssClasses;
 
     if (child.props.className) {
@@ -83,6 +84,7 @@ var renderSlides = (spec) => {
       key: 'original' + getKey(child, index),
       'data-index': index,
       className: cssClasses,
+      slickActive: slickActive,
       style: assign({}, child.props.style || {}, childStyle)
     }));
 


### PR DESCRIPTION
Looking for a cleaner way to know if the slide is being actively rendered or not. 

this would be helpful. 

Used `slickActive` instead of `rendered` or `active` because i think they're a bit generic.  

Helps us know when cards are seen or not.