### PR TITLE
Add babel-plugin-transform-object-assign for backwards compatibility …

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,6 @@
   "presets":[
     "react",
     "es2015-loose"
-  ]
+  ],
+  "plugins": ["transform-object-assign"]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-core": "^6.9.0",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-object-assign": "^6.3.13",
     "babel-preset-airbnb": "^2.0.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es2015-loose": "^7.0.0",


### PR DESCRIPTION
…with older browsers

The use of ES6's `Object.assign` function in https://github.com/akiran/react-slick/blob/master/src/inner-slider.jsx#L17 is causing a failure in our CI builds when they test on older browsers. The [babel-plugin-transform-object-assign plugin](https://www.npmjs.com/package/babel-plugin-transform-object-assign) keeps that from happening.

Failure examples:
```
Chrome 35.0.1916 (Windows 7 0.0.0) components - common - carousel mounts to the DOM with a loading state FAILED
	TypeError: undefined is not a function
	    at getInitialState (/home/travis/build/paddle8/nauman/tests.webpack.js:36156:20 <- webpack:///~/react-slick/lib/inner-slider.js:45:0)
```
```
Firefox 30.0.0 (Linux 0.0.0) components - common - carousel mounts to the DOM with a loading state FAILED
	Object.assign is not a function
	getInitialState@/home/travis/build/paddle8/nauman/tests.webpack.js:36157:1 <- webpack:///~/react-slick/lib/inner-slider.js:46:0
```
```
Mobile Safari 7.0.0 (iOS 7.1.0) components - common - carousel mounts to the DOM with a loading state FAILED
	'undefined' is not a function (evaluating 'Object.assign({}, _initialState2.default, {
		      currentSlide: this.props.initialSlide
		    })')
	InnerSlider_getInitialState@/home/travis/build/paddle8/nauman/tests.webpack.js:36156:26 <- webpack:///~/react-slick/lib/inner-slider.js:45:0
```
```
IE 11.0.0 (Windows 8.1 0.0.0) components - common - carousel mounts to the DOM with a loading state FAILED
	TypeError: Object doesn't support property or method 'assign'
	   at getInitialState (/home/travis/build/paddle8/nauman/tests.webpack.js:36156:6 <- webpack:///~/react-slick/lib/inner-slider.js:45:0)
```