### PR TITLE
Fix two edge case issues.

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -43,6 +43,8 @@ var helpers = {
     var trackWidth = this.getWidth(ReactDOM.findDOMNode(this.refs.track));
     var slideWidth = this.getWidth(ReactDOM.findDOMNode(this))/props.slidesToShow;
 
+    var currentSlide = props.rtl ? slideCount - 1 - props.initialSlide : props.initialSlide;
+
     // pause slider if autoplay is set to false
     if(!props.autoplay)
       this.pause();
@@ -51,7 +53,8 @@ var helpers = {
       slideCount: slideCount,
       slideWidth: slideWidth,
       listWidth: listWidth,
-      trackWidth: trackWidth
+      trackWidth: trackWidth,
+      currentSlide: currentSlide
     }, function () {
 
       var targetLeft = getTrackLeft(assign({

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -67,7 +67,7 @@ export var getTrackLeft = function (spec) {
   }
 
   if (spec.infinite) {
-    if (spec.slideCount > spec.slidesToShow) {
+    if (spec.slideCount >= spec.slidesToShow) {
      slideOffset = (spec.slideWidth * spec.slidesToShow) * -1;
     }
     if (spec.slideCount % spec.slidesToScroll !== 0) {


### PR DESCRIPTION
1. https://github.com/akiran/react-slick/commit/ed7447fbce84754116b334fc013769897ab5cb75 This commit fixed the back scrolling animation when there's only one slide and we set `inifinite: true`.
2. https://github.com/akiran/react-slick/commit/7634fa54b31a8bc8b979e4d0c0d3fbf37ceea0a8 This commit fixed the update of `currentSlide` when the number of slides may change frequently.