### PR TITLE
Only scroll to the last visible item when a set is uneven and infinite = false

### DIFF
--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -7,7 +7,8 @@ import SimpleSlider from '../examples/SimpleSlider'
 import SlideChangeHooks from '../examples/SlideChangeHooks'
 import MultipleItems from '../examples/MultipleItems'
 import Responsive from '../examples/Responsive'
-import UnevenSets from '../examples/UnevenSets'
+import UnevenSetsInfinite from '../examples/UnevenSetsInfinite'
+import UnevenSetsFinite from '../examples/UnevenSetsFinite'
 import CenterMode from '../examples/CenterMode'
 import FocusOnSelect from '../examples/FocusOnSelect'
 import AutoPlay from '../examples/AutoPlay'
@@ -21,6 +22,7 @@ import SlickGoTo from '../examples/SlickGoTo'
 import CustomArrows from '../examples/CustomArrows'
 import DynamicSlides  from '../examples/DynamicSlides'
 
+
 export default class App extends React.Component {
   render() {
     return (
@@ -28,7 +30,8 @@ export default class App extends React.Component {
         <SimpleSlider />
         <MultipleItems />
         <Responsive />
-        <UnevenSets />
+        <UnevenSetsInfinite />
+        <UnevenSetsFinite />
         <CenterMode />
         <FocusOnSelect />
         <AutoPlay />

--- a/examples/UnevenSetsFinite.js
+++ b/examples/UnevenSetsFinite.js
@@ -1,18 +1,18 @@
 import React, { Component } from 'react'
 import Slider from '../src/slider'
 
-export default class UnevenSets extends Component {
+export default class UnevenSetsFinite extends Component {
   render() {
     var settings = {
       dots: true,
-      infinite: true,
+      infinite: false,
       speed: 500,
       slidesToScroll: 4,
       slidesToShow: 4
     };
     return (
       <div>
-        <h2>Uneven sets</h2>
+        <h2>Uneven sets (finite)</h2>
         <Slider {...settings}>
           <div><h3>1</h3></div>
           <div><h3>2</h3></div>

--- a/examples/UnevenSetsInfinite.js
+++ b/examples/UnevenSetsInfinite.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react'
+import Slider from '../src/slider'
+
+export default class UnevenSetsInfinite extends Component {
+  render() {
+    var settings = {
+      dots: true,
+      infinite: true,
+      speed: 500,
+      slidesToScroll: 4,
+      slidesToShow: 4
+    };
+    return (
+      <div>
+        <h2>Uneven sets (infinite)</h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+          <div><h3>5</h3></div>
+          <div><h3>6</h3></div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -79,7 +79,17 @@ export var getTrackLeft = function (spec) {
           }
       }
     }
+  } else {
+
+    if (spec.slideCount % spec.slidesToScroll !== 0) {
+      if (spec.slideIndex + spec.slidesToScroll > spec.slideCount && spec.slideCount > spec.slidesToShow) {
+          var slidesToOffset = spec.slidesToShow - (spec.slideCount % spec.slidesToScroll);
+          slideOffset = slidesToOffset * spec.slideWidth;
+      }
+    }
   }
+
+
 
   if (spec.centerMode) {
     if(spec.infinite) {


### PR DESCRIPTION
Presently, when ```infinite = false```, and the carousel has an uneven set, it will slide to the end of the number of slides to show, even if the carousel doesn't have enough items to fill the space. Example below:

![screen shot 2016-08-19 at 3 13 11 pm](https://cloud.githubusercontent.com/assets/365105/17821499/f93a762e-661f-11e6-9e3a-98496e68d186.png)

The correct behavior (IMO) should be the same as if infinite were ```true```  - scroll until the end of the visible item, like this:

![screen shot 2016-08-19 at 3 17 54 pm](https://cloud.githubusercontent.com/assets/365105/17821539/2294e568-6620-11e6-87cc-d64d34c66e39.png)

This PR does the following: 

1. adds an example of an uneven set that is not infinite, and;
2. sets the offset so that it will only scroll to the last visible item.
