### PR TITLE
Fixes Swipe too far in infinite == false did not reset to previous position

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -156,11 +156,6 @@ var helpers = {
       currentSlide = targetSlide;
     }
 
-    // Don't change slide if it's not infite and current slide is the first or last slide page.
-    if(currentSlide === this.state.currentSlide && this.props.infinite === false) {
-      return;
-    }
-
     targetLeft = getTrackLeft(assign({
       slideIndex: targetSlide,
       trackRef: this.refs.track


### PR DESCRIPTION
Hi,

When the slider has infinite mode == false and we slide too far, the slider doesn't refresh the position of the slides on swipe end, so they are stuck in the middle instead of being moved back to the original position. The fix is that even if the slide number doesn't change, we should still update the state to refresh the position.

Before PR:
![beforepr_image](http://louistremblay.s3.amazonaws.com/swipe_beforePR.gif)

After PR:
![afterpr_image](http://louistremblay.s3.amazonaws.com/swipe_afterPR.gif)
