### PR TITLE
Changed input's initialValue prop to defaultValue.

### DIFF
--- a/examples/SlickGoTo.js
+++ b/examples/SlickGoTo.js
@@ -21,7 +21,7 @@ export default class SlickGoTo extends Component {
     return (
       <div>
         <h2>Slick Go To</h2>
-        <input onChange={this.changeHandler} initialValue={0} type='range' min={0} max={3} />
+        <input onChange={this.changeHandler} defaultValue={0} type='range' min={0} max={3} />
         <Slider ref='slider' {...settings}>
           <div><img src={baseUrl + '/abstract01.jpg'} /></div>
           <div><img src={baseUrl + '/abstract02.jpg'} /></div>


### PR DESCRIPTION
I've noticed that, in the SlickGoTo example, there is an input with the initialValue property set to 0. If I'm not mistaken, that initialValue prop should be defaultValue instead.

Note to self: I also have [#449](https://github.com/akiran/react-slick/pull/449) open, will rebase if one or the other is merged/accepted first.