### PR TITLE
Default`pauseOnHover` should be true

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -18,7 +18,7 @@ var defaultProps = {
     infinite: true,
     initialSlide: 0,
     lazyLoad: false,
-    pauseOnHover: false,
+    pauseOnHover: true,
     responsive: null,
     rtl: false,
     slide: 'div',


### PR DESCRIPTION
Which is described in [README](https://github.com/akiran/react-slick/blob/master/README.md)