### PR TITLE
Fix for #461: avoid code evaluation when !focusOnSelect

### DIFF
--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -130,7 +130,7 @@ export var InnerSlider = React.createClass({
       speed: this.props.speed,
       infinite: this.props.infinite,
       centerMode: this.props.centerMode,
-      focusOnSelect: this.props.focusOnSelect ? this.selectHandler : new Function(),
+      focusOnSelect: this.props.focusOnSelect ? this.selectHandler : null,
       currentSlide: this.state.currentSlide,
       lazyLoad: this.props.lazyLoad,
       lazyLoadedList: this.state.lazyLoadedList,

--- a/src/track.jsx
+++ b/src/track.jsx
@@ -89,7 +89,9 @@ var renderSlides = function (spec) {
 
     const onClick = function(e) {
       child.props && child.props.onClick && child.props.onClick(e)
-      spec.focusOnSelect(childOnClickOptions)
+      if (spec.focusOnSelect) {
+        spec.focusOnSelect(childOnClickOptions)
+      }
     }
 
     slides.push(React.cloneElement(child, {


### PR DESCRIPTION
If `!focusOnSelect` then `new Function` is executed. This is actually
code evaluation. Use an empty function instead.