### PR TITLE
SwipeToSlide with Vertical Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ var SimpleSlider = React.createClass({
 | slidesToScroll | int | Number of slides to scroll for each navigation item
 | speed | int |||
 | swipe | bool |||
-| swipeToSlide | bool |||
+| swipeToSlide | bool | Allow users to drag or swipe directly to a slide irrespective of slidesToScroll | Yes |
 | touchMove | bool |||
 | touchThreshold | int |||
 | variableWidth | bool |||
 | useCSS | bool | Enable/Disable CSS Transitions | Yes |
-| vertical | bool |||
+| vertical | bool | Vertical slide mode | Yes |
 | afterChange | function | callback function called after the current index changes | Yes |
 | beforeChange | function | callback function called before the current index changes | Yes |
 | slickGoTo | int | go to the specified slide number | |

--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -24,6 +24,7 @@ import PreviousNextMethods from '../examples/PreviousNextMethods'
 import DynamicSlides  from '../examples/DynamicSlides'
 import VerticalMode  from '../examples/VerticalMode'
 import SwipeToSlide from '../examples/SwipeToSlide'
+import VerticalSwipeToSlide from '../examples/VerticalSwipeToSlide'
 
 export default class App extends React.Component {
   render() {
@@ -50,6 +51,7 @@ export default class App extends React.Component {
         <DynamicSlides />
         <VerticalMode />
         <SwipeToSlide />
+        <VerticalSwipeToSlide />
       </div>
     );
   }

--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -23,6 +23,7 @@ import CustomArrows from '../examples/CustomArrows'
 import PreviousNextMethods from '../examples/PreviousNextMethods'
 import DynamicSlides  from '../examples/DynamicSlides'
 import VerticalMode  from '../examples/VerticalMode'
+import SwipeToSlide from '../examples/SwipeToSlide'
 
 export default class App extends React.Component {
   render() {
@@ -48,6 +49,7 @@ export default class App extends React.Component {
         <PreviousNextMethods />
         <DynamicSlides />
         <VerticalMode />
+        <SwipeToSlide />
       </div>
     );
   }

--- a/examples/SwipeToSlide.js
+++ b/examples/SwipeToSlide.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react'
+import Slider from '../src/slider'
+
+export default class SwipeToSlide extends Component {
+  render() {
+    const settings = {
+      className: 'center',
+      infinite: true,
+      centerPadding: '60px',
+      slidesToShow: 5,
+      swipeToSlide: true,
+      afterChange: function (index) {
+        console.log(`Slider Changed to: ${index + 1}, background: #222; color: #bada55`);
+      }
+    };
+    return (
+      <div>
+        <h2>Swipe To Slide</h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+          <div><h3>5</h3></div>
+          <div><h3>6</h3></div>
+          <div><h3>7</h3></div>
+          <div><h3>8</h3></div>
+          <div><h3>9</h3></div>
+        </Slider>
+      </div>
+    )
+  }
+}

--- a/examples/VerticalSwipeToSlide.js
+++ b/examples/VerticalSwipeToSlide.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react'
+import Slider from '../src/slider'
+
+export default class VerticalSwipeToSlide extends Component {
+  render() {
+    const settings = {
+      dots: true,
+      infinite: true,
+      slidesToShow: 3,
+      slidesToScroll: 1,
+      vertical: true,
+      verticalSwiping: true,
+      swipeToSlide: true,
+      beforeChange: function (currentSlide, nextSlide) {
+        console.log('before change', currentSlide, nextSlide);
+      },
+      afterChange: function (currentSlide) {
+        console.log('after change', currentSlide);
+      },
+    };
+    return (
+      <div>
+        <h2>Vertical Mode with Swipe To Slide</h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+          <div><h3>5</h3></div>
+          <div><h3>6</h3></div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -177,6 +177,25 @@ var EventHandlers = {
 
     return indexes;
   },
+  checkNavigable(index) {
+    const navigables = this.getNavigableIndexes();
+    let prevNavigable = 0;
+
+    if (index > navigables[navigables.length - 1]) {
+      index = navigables[navigables.length - 1];
+    } else {
+      for (var n in navigables) {
+        if (index < navigables[n]) {
+          index = prevNavigable;
+          break;
+        }
+
+        prevNavigable = navigables[n];
+      }
+    }
+
+    return index;
+  },
   swipeEnd: function (e) {
     if (!this.state.dragging) {
       e.preventDefault();

--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -251,19 +251,30 @@ var EventHandlers = {
     if (touchObject.swipeLength > minSwipe) {
       e.preventDefault();
 
+      let slideCount, newSlide;
+
       switch (swipeDirection) {
+
         case 'left':
         case 'down':
-          this.slideHandler(this.state.currentSlide + this.props.slidesToScroll);
+          newSlide = this.state.currentSlide + this.getSlideCount();
+          slideCount = this.props.swipeToSlide ? this.checkNavigable(newSlide) : newSlide;
+          this.state.currentDirection = 0;
           break;
 
         case 'right':
         case 'up':
-          this.slideHandler(this.state.currentSlide - this.props.slidesToScroll);
+          newSlide = this.state.currentSlide - this.getSlideCount();
+          slideCount = this.props.swipeToSlide ? this.checkNavigable(newSlide) : newSlide;
+          this.state.currentDirection = 1;
           break;
 
         default:
+          slideCount = this.state.currentSlide;
+
       }
+
+      this.slideHandler(slideCount);
     } else {
       // Adjust the track back to it's original position.
       var currentLeft = getTrackLeft(assign({

--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -2,6 +2,7 @@
 import {getTrackCSS, getTrackLeft, getTrackAnimateCSS} from './trackHelper';
 import helpers from './helpers';
 import assign from 'object-assign';
+import ReactDOM from 'react-dom';
 
 var EventHandlers = {
   // Event handler for previous and next
@@ -195,6 +196,32 @@ var EventHandlers = {
     }
 
     return index;
+  },
+  getSlideCount() {
+    const centerOffset = this.props.centerMode ? this.state.slideWidth * Math.floor(this.props.slidesToShow / 2) : 0;
+
+    if (this.props.swipeToSlide) {
+      let swipedSlide;
+
+      const slickList = ReactDOM.findDOMNode(this.list);
+
+      const slides = slickList.querySelectorAll('.slick-slide');
+
+      Array.from(slides).every((slide) => {
+        if (slide.offsetLeft - centerOffset + (this.getWidth(slide) / 2) > this.state.swipeLeft * -1) {
+          swipedSlide = slide;
+          return false;
+        }
+
+        return true;
+      });
+
+      const slidesTraversed = Math.abs(swipedSlide.dataset.index - this.state.currentSlide) || 1;
+
+      return slidesTraversed;
+    } else {
+      return this.props.slidesToScroll;
+    }
   },
   swipeEnd: function (e) {
     if (!this.state.dragging) {

--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -153,6 +153,30 @@ var EventHandlers = {
       e.preventDefault();
     }
   },
+  getNavigableIndexes() {
+    let max;
+    let breakPoint = 0;
+    let counter = 0;
+    let indexes = [];
+
+    if (!this.props.infinite) {
+      max = this.state.slideCount;
+    } else {
+      breakPoint = this.props.slidesToShow * -1;
+      counter = this.props.slidesToShow * -1;
+      max = this.state.slideCount * 2;
+    }
+
+    while (breakPoint < max) {
+      indexes.push(breakPoint);
+      breakPoint = counter + this.props.slidesToScroll;
+
+      counter += this.props.slidesToScroll <= this.props.slidesToShow ?
+        this.props.slidesToScroll : this.props.slidesToShow;
+    }
+
+    return indexes;
+  },
   swipeEnd: function (e) {
     if (!this.state.dragging) {
       e.preventDefault();

--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -208,9 +208,16 @@ var EventHandlers = {
       const slides = slickList.querySelectorAll('.slick-slide');
 
       Array.from(slides).every((slide) => {
-        if (slide.offsetLeft - centerOffset + (this.getWidth(slide) / 2) > this.state.swipeLeft * -1) {
-          swipedSlide = slide;
-          return false;
+        if (!this.props.vertical) {
+          if (slide.offsetLeft - centerOffset + (this.getWidth(slide) / 2) > this.state.swipeLeft * -1) {
+            swipedSlide = slide;
+            return false;
+          }
+        } else {
+          if (slide.offsetTop + (this.getHeight(slide) / 2) > this.state.swipeLeft * -1) {
+            swipedSlide = slide;
+            return false;
+          }
         }
 
         return true;


### PR DESCRIPTION
This is a basic implementation of the 'swipeToSlide' property, including readme and demo. A similar pull request for this feature already exists, but I've implemented the feature myself with a view to making the 'swipeToSlide' property compatible with the vertical mode and vertical swiping, something that is not present in the original slick carousel library. The following briefly details the changes made:

- Description of 'swipeToSlide' added to the readme.
- SwipeToSlide and VerticalSwipeToSlide examples added to the demo.
- getSlideCount, checkNavigable and getNavigableIndexes methods from the original library reimplemented.
- These methods used to provide swipeToSlide functionality in the swipeEnd method.
- If swipeToSlide is set to false the behaviour here is no different, and the number of slides moved is still the value in the 'slidesToScroll' property. 
- Otherwise, the methods mentioned determine the number of slides to scroll based on the swipe event.