### PR TITLE
Fixed #465.

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -15,9 +15,9 @@ var helpers = {
     var slideWidth;
 
     if (!props.vertical) {
-      slideWidth = trackWidth/props.slidesToShow;
+      slideWidth = this.getWidth(ReactDOM.findDOMNode(this))/props.slidesToShow;
     } else {
-      slideWidth = trackWidth;
+      slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
     }
 
     const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));
@@ -57,9 +57,9 @@ var helpers = {
     var slideWidth;
 
     if (!props.vertical) {
-      slideWidth = trackWidth/props.slidesToShow;
+      slideWidth = this.getWidth(ReactDOM.findDOMNode(this))/props.slidesToShow;
     } else {
-      slideWidth = trackWidth;
+      slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
     }
 
     const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));


### PR DESCRIPTION
Fixed issue #465, which originates in the helpers file in the update method specifically. For whatever reason the bug is not highlighted by calls to the initialize helper.

 - slideWidth used trackWidth directly in calculations, but this.track is not the same thing as this.