### PR TITLE
Custom unslick

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ var SimpleSlider = React.createClass({
 | initialSlide   | int | which item should be the first to be displayed | Yes |
 | lazyLoad       | bool | Loads images or renders components on demands | Yes |
 | pauseOnHover   | bool | prevents autoplay while hovering | Yes |
-| responsive     | array | Array of objects in the form of `{ breakpoint: int, settings: { ... } }` The breakpoint _int_ is the `maxWidth` so the settings will be applied when resolution is below this value. Breakpoints in the array should be ordered from smalles to greatest. Use 'unslick' in place of the settings object to disable rendering the carousel at that breakpoint. Example: `[ { breakpoint: 768, settings: { slidesToShow: 3 } }, { breakpoint: 1024, settings: { slidesToShow: 5 } }, { breakpoint: 100000, settings: 'unslick' } ]`| Yes |
+| responsive     | array | Array of objects in the form of `{ breakpoint: int, settings: { ... } }` The breakpoint _int_ is the `maxWidth` so the settings will be applied when resolution is below this value. Breakpoints in the array should be ordered from smalles to greatest. Use 'unslick' in place of the settings object to disable rendering the carousel at that breakpoint. Example: `[ { breakpoint: 768, responsiveUnslick: func(), settings: { slidesToShow: 3 } }, { breakpoint: 1024, responsiveUnslick: func(), settings: { slidesToShow: 5 } }, { breakpoint: 100000, settings: 'unslick' } ]`| Yes |
 | rtl            | bool | Reverses the slide order | Yes |
 | slide         | string |||
 | slidesToShow | int | Number of slides to be visible at a time | Yes |
@@ -137,7 +137,7 @@ class LeftNavButton extends React.Component {
 Important: be sure that you pass your component's props to your clickable element
 like the example above. If you don't, your custom component won't trigger the click handler.
 
-You can also set onClick={this.props.onClick} if you only want to set the click handler. 
+You can also set onClick={this.props.onClick} if you only want to set the click handler.
 
 ### Flexbox support 
 If you have flex property on container div of slider, add below css

--- a/examples/Responsive.js
+++ b/examples/Responsive.js
@@ -1,6 +1,17 @@
 import React, { Component } from 'react'
 import Slider from '../src/slider'
 
+// return a custom unslicked carousel
+class UnSlick extends Component {
+  render(){
+    return (
+      <div className="my-unslick">
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
 export default class Responsive extends Component {
   render() {
     var settings = {
@@ -10,6 +21,7 @@ export default class Responsive extends Component {
       slidesToShow: 4,
       slidesToScroll: 4,
       initialSlide: 0,
+      unslick: UnSlick,
       responsive: [{
         breakpoint: 1024,
         settings: {

--- a/examples/Responsive.js
+++ b/examples/Responsive.js
@@ -32,10 +32,13 @@ export default class Responsive extends Component {
         }
       }, {
         breakpoint: 600,
+        responsiveUnslick: function({children,newProps,props,state}){
+          return children.length < newProps.settings.slidesToShow;
+        },
         settings: {
           slidesToShow: 2,
-          slidesToScroll: 2,
-          initialSlide: 2
+          slidesToScroll: 1,
+          initialSlide: 2,
         }
       }, {
         breakpoint: 480,

--- a/src/slider.js
+++ b/src/slider.js
@@ -59,15 +59,9 @@ var Slider = React.createClass({
   render: function () {
     var settings;
     var newProps;
-    if (this.state.breakpoint) {
-      newProps = this.props.responsive.filter(resp => resp.breakpoint === this.state.breakpoint);
-      settings = newProps[0].settings === 'unslick' ? 'unslick' : assign({}, this.props, newProps[0].settings);
-    } else {
-      settings = assign({}, defaultProps, this.props);
-    }
-
     var UnSlickComponent = typeof this.props.unslick === 'function' && this.props.unslick;
     var children = this.props.children;
+
     if(!Array.isArray(children)) {
       children = [children]
     }
@@ -76,6 +70,19 @@ var Slider = React.createClass({
     children = children.filter(function(child){
       return !!child
     })
+
+    if (this.state.breakpoint) {
+      newProps = this.props.responsive.filter(resp => resp.breakpoint === this.state.breakpoint)[0];
+      // allow for custom unslick function instead of strictly static settings
+      unslick = newProps.settings === 'unslick' || (
+        typeof newProps.responsiveUnslick === 'function' &&
+          newProps.responsiveUnslick({children,newProps,state: this.state, props: this.props})
+      )
+
+      settings = unslick ? 'unslick' : assign({}, this.props, newProps.settings);
+    } else {
+      settings = assign({}, defaultProps, this.props);
+    }
 
     // if 'unslick' responsive breakpoint setting used, just return the <Slider> tag nested HTML
     if (settings === 'unslick') {

--- a/src/slider.js
+++ b/src/slider.js
@@ -59,6 +59,7 @@ var Slider = React.createClass({
   render: function () {
     var settings;
     var newProps;
+    var unslickBool = false;
     var UnSlickComponent = typeof this.props.unslick === 'function' && this.props.unslick;
     var children = this.props.children;
 
@@ -74,12 +75,12 @@ var Slider = React.createClass({
     if (this.state.breakpoint) {
       newProps = this.props.responsive.filter(resp => resp.breakpoint === this.state.breakpoint)[0];
       // allow for custom unslick function instead of strictly static settings
-      unslick = newProps.settings === 'unslick' || (
+      unslickBool = newProps.settings === 'unslick' || (
         typeof newProps.responsiveUnslick === 'function' &&
           newProps.responsiveUnslick({children,newProps,state: this.state, props: this.props})
       )
 
-      settings = unslick ? 'unslick' : assign({}, this.props, newProps.settings);
+      settings = unslickBool ? 'unslick' : assign({}, this.props, newProps.settings);
     } else {
       settings = assign({}, defaultProps, this.props);
     }

--- a/src/slider.js
+++ b/src/slider.js
@@ -66,6 +66,7 @@ var Slider = React.createClass({
       settings = assign({}, defaultProps, this.props);
     }
 
+    var UnSlickComponent = typeof this.props.unslick === 'function' && this.props.unslick;
     var children = this.props.children;
     if(!Array.isArray(children)) {
       children = [children]
@@ -76,11 +77,17 @@ var Slider = React.createClass({
       return !!child
     })
 
+    // if 'unslick' responsive breakpoint setting used, just return the <Slider> tag nested HTML
     if (settings === 'unslick') {
-      // if 'unslick' responsive breakpoint setting used, just return the <Slider> tag nested HTML
-      return (
-        <div>{children}</div>
-      );
+      if (UnSlickComponent) {
+        return (
+          <UnSlickComponent>{children}</UnSlickComponent>
+        );
+      } else {
+        return (
+          <div>{children}</div>
+        );
+      }
     } else {
       return (
         <InnerSlider ref={this.innerSliderRefHandler} {...settings}>


### PR DESCRIPTION
This PR adds unslick customizations. 

- allows for a custom `Unslick` component to be passed in as a prop and used when the slider is unslicked. 
- allows for a responsiveUnslick function to be defined for each breakpoint. If the callback is defined it is used to determine if the slider should switch to unslick

