### PR TITLE
fixed flickering on window  resize with responsive and autoplay

### DIFF
--- a/src/inner-slider.jsx
+++ b/src/inner-slider.jsx
@@ -107,7 +107,9 @@ export var InnerSlider = React.createClass({
     // animating state should be cleared while resizing, otherwise autoplay stops working
     this.setState({
       animating: false
-    })
+    });
+    clearTimeout(this.animationEndCallback);
+    delete this.animationEndCallback;
   },
   slickPrev: function () {
     this.changeSlide({message: 'previous'});


### PR DESCRIPTION
There was a lot of flickering when using responsive option and changing size with autoplay enabled.
This fix eliminates the problem.