### PR TITLE
feat: add support for setting autoplaySpeed in the each slide individually

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -179,7 +179,7 @@ var helpers = {
         this.props.beforeChange(this.state.currentSlide, targetSlide);
       }
 
-      this.autoPlay();
+      this.autoPlay(this.props.children[targetSlide].props.autoplaySpeed || this.props.autoplaySpeed);
       return;
     }
 
@@ -329,19 +329,19 @@ var helpers = {
 
     this.slideHandler(nextIndex);
   },
-  autoPlay: function () {
+  autoPlay: function (autoplaySpeed) {
     if (this.state.autoPlayTimer) {
-      return;
+      clearTimeout(this.state.autoPlayTimer);
     }
     if (this.props.autoplay) {
       this.setState({
-        autoPlayTimer: setInterval(this.play, this.props.autoplaySpeed)
+        autoPlayTimer: setTimeout(this.play, autoplaySpeed || this.props.autoplaySpeed)
       });
     }
   },
   pause: function () {
     if (this.state.autoPlayTimer) {
-      clearInterval(this.state.autoPlayTimer);
+      clearTimeout(this.state.autoPlayTimer);
       this.setState({
         autoPlayTimer: null
       });


### PR DESCRIPTION
We have a requirement where we need to set different autoplaySpeed to each slide depending on type of the slide.

I am not sure whether you will want to keep this as a part of the main repo. But looks like will be useful for someone having similar requirement. 

I will build upon this pull request with example and documentation if you are interested.

PS : This also fixes one of the problem in autoplay where slide always changes based on interval time set even if user is interacting with the slides. Ideally time should reset if user has changed the slide himself.