### PR TITLE
Error when targetLeft is not available

### DIFF
--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -143,8 +143,9 @@ export var getTrackLeft = function (spec) {
               targetSlide = ReactDOM.findDOMNode(spec.trackRef).children[(spec.slideIndex + spec.slidesToShow + 1)];
           }
 
-          targetLeft = targetSlide ? targetSlide.offsetLeft * -1 : 0;
-          targetLeft += (spec.listWidth - targetSlide.offsetWidth) / 2;
+          if (targetSlide) {
+            targetLeft = targetSlide.offsetLeft * -1 + (spec.listWidth - targetSlide.offsetWidth) / 2;
+          }
       }
   }
 


### PR DESCRIPTION
We currently see that lots of our users get an error from the slick carousel.
We are using `variableWidth: true`, `centerMode: true`, `infinite: false` and when the user swipes the content to the right to show the non-existing slide to the left it causes the following error:

```
TypeError: undefined is not an object (evaluating 'targetSlide.offsetWidth')
```