### PR TITLE
Only suppress default if swipe is enabled

### DIFF
--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -235,7 +235,9 @@ var EventHandlers = {
   },
   swipeEnd: function (e) {
     if (!this.state.dragging) {
-      e.preventDefault();
+      if (this.props.swipe) {
+        e.preventDefault();
+      }
       return;
     }
     var touchObject = this.state.touchObject;


### PR DESCRIPTION
Issue: Having items with click handlers inside react-slick do not get
triggered when the option swipe is set to false.

This is because `swipeEnd` called `preventDefault()`.

Tested on: iPad mini 4 & iPad Air 2 Simulator