### PR TITLE
fixing numerous bugs when calculating the slide offset for finite sets

### DIFF
--- a/examples/UnevenSetsFinite.js
+++ b/examples/UnevenSetsFinite.js
@@ -7,7 +7,7 @@ export default class UnevenSetsFinite extends Component {
       dots: true,
       infinite: false,
       speed: 500,
-      slidesToScroll: 4,
+      slidesToScroll: 3,
       slidesToShow: 4
     };
     return (
@@ -20,6 +20,11 @@ export default class UnevenSetsFinite extends Component {
           <div><h3>4</h3></div>
           <div><h3>5</h3></div>
           <div><h3>6</h3></div>
+          <div><h3>7</h3></div>
+          <div><h3>8</h3></div>
+          <div><h3>9</h3></div>
+          <div><h3>10</h3></div>
+          <div><h3>11</h3></div>
         </Slider>
       </div>
     );

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -103,12 +103,11 @@ export var getTrackLeft = function (spec) {
     }
   } else {
 
-    if (spec.slideCount % spec.slidesToScroll !== 0) {
-      if (spec.slideIndex + spec.slidesToScroll > spec.slideCount && spec.slideCount > spec.slidesToShow) {
-          var slidesToOffset = spec.slidesToShow - (spec.slideCount % spec.slidesToScroll);
-          slideOffset = slidesToOffset * spec.slideWidth;
-      }
+    if (spec.slideIndex + spec.slidesToShow > spec.slideCount) {
+      var slidesToOffset = spec.slidesToShow - (spec.slideCount % spec.slideIndex);
+      slideOffset = slidesToOffset * spec.slideWidth;
     }
+
   }
 
 


### PR DESCRIPTION
It looks like my [previous PR](https://github.com/akiran/react-slick/pull/425) didn't address all possible conditions for a finite carousel. This one seems to. I tested it with all different kinds of combinations of slidesToScroll, slidesToShow and the total number of slides, and it seems to work.