### PR TITLE
Enable server-side rendering of dots/pagers

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -50,6 +50,10 @@ export var InnerSlider = createReactClass({
         lazyLoadedList: lazyLoadedList
       });
     }
+
+    if (typeof window === 'undefined') {
+      this.serverInitialize(this.props);
+    }
   },
   componentDidMount: function componentDidMount() {
     // Hack for autoplay -- Inspect Later

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -6,6 +6,16 @@ import {getTrackCSS, getTrackLeft, getTrackAnimateCSS} from './trackHelper';
 import assign from 'object-assign';
 
 var helpers = {
+  serverInitialize: function (props) {
+    var slideCount = React.Children.count(props.children);
+    var currentSlide = props.rtl ? slideCount - 1 - props.initialSlide : props.initialSlide;
+
+    this.setState({
+      slideCount,
+      currentSlide
+    });
+  },
+
   initialize: function (props) {
     const slickList = ReactDOM.findDOMNode(this.list);
 


### PR DESCRIPTION
The `slideCount` and `currentSlide` values can easily be calculated during server-side rendering already. 
When we do that, it will get the the dots/pagers rendered on server side already in isomorphic apps, thus preventing any "jumping" of the page content after JavaScript has been initialized. 

It would fix part of what #509 tries to do. 