### PR TITLE
Add `slick-initialized` on client-side only

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -53,6 +53,8 @@ export var InnerSlider = createReactClass({
 
     if (typeof window === 'undefined') {
       this.serverInitialize(this.props);
+    } else {
+      this.setState({ initialized: true });
     }
   },
   componentDidMount: function componentDidMount() {
@@ -131,8 +133,9 @@ export var InnerSlider = createReactClass({
     });
   },
   render: function () {
-    var className = classnames('slick-initialized', 'slick-slider', this.props.className, {
+    var className = classnames('slick-slider', this.props.className, {
       'slick-vertical': this.props.vertical,
+      'slick-initialized': this.state.initialized
     });
 
     var trackProps = {

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -50,6 +50,10 @@ export var InnerSlider = createReactClass({
         lazyLoadedList: lazyLoadedList
       });
     }
+
+    if (typeof window === 'undefined') {
+      this.serverInitialize(this.props);
+    }
   },
   componentDidMount: function componentDidMount() {
     // Hack for autoplay -- Inspect Later

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -6,6 +6,16 @@ import {getTrackCSS, getTrackLeft, getTrackAnimateCSS} from './trackHelper';
 import assign from 'object-assign';
 
 var helpers = {
+  serverInitialize: function (props) {
+    var slideCount = React.Children.count(props.children);
+    var currentSlide = props.rtl ? slideCount - 1 - props.initialSlide : props.initialSlide;
+
+    this.setState({
+      slideCount,
+      currentSlide
+    });
+  },
+
   initialize: function (props) {
     const slickList = ReactDOM.findDOMNode(this.list);
 


### PR DESCRIPTION
(This PR builds on the changes of #559; thus those changes are included in the diff as well.)

When using `react-slick` in isomorphic apps, the slider will be rendered before any client-side JavaScript has been run, leading to issues like #254, #508, or #537. 

This PR provides a simple solution based on the `initialized` state that's already included in `initial-state.js`. It's a more React-like solution compared to #256. 
By calling the `setState` in `componentWillMount` we prevent unnecessary re-rendering on pure client-side apps. 

Compared to #288 this change implicitly takes the `slidesToShow` into account, as the `slick-active` class already handles that correctly.

----

After applying those changes, users will be able to optionally add the following styles in order to display the active slide while javascript has not been initialized yet:
```css
.slick-slide.slick-active {
    display: block;
}
```
**Edit:** It's actually also necessary to add something like the following. Otherwise you end up with the active slide being shown twice.
```css
.slick-track {
    width: 9000px;
}
```