### PR TITLE
error: Cannot read property 'dataset' of undefined

### DIFF
--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -226,7 +226,7 @@ var EventHandlers = {
         return true;
       });
 
-      const slidesTraversed = Math.abs(swipedSlide.dataset.index - this.state.currentSlide) || 1;
+      const slidesTraversed = Math.abs(swipedSlide && swipedSlide.dataset.index - this.state.currentSlide) || 1;
 
       return slidesTraversed;
     } else {


### PR DESCRIPTION
Fix for
```event-handlers.js:250 Uncaught TypeError: Cannot read property 'dataset' of undefined```
error when using
```
    infinite: false,
    slidesToScroll: 1,
    centerMode: true,
    slidesToShow: 3,
    adaptiveHeight: false,
    arrows: false,
    beforeChange: this.handleBeforeChange,
    afterChange: this.handleAfterChange,
    initialSlide: this.state.initialSlide || 1,
    lazyLoad: false,
    swipeToSlide: true,
``` 
settings.
Getting this error when scrolling slides to the left.
In this situation, slider freezes and error is thrown.
![image](https://cloud.githubusercontent.com/assets/17516160/20742430/b182c58e-b6d8-11e6-8bad-971645dcd887.png)
