### PR TITLE
Fix using non-px values for centerPadding option

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -15,8 +15,7 @@ var helpers = {
     var slideWidth;
 
     if (!props.vertical) {
-      var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
-      slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj)/props.slidesToShow;
+      slideWidth = Math.ceil(listWidth / props.slidesToShow);
     } else {
       slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
     }
@@ -58,8 +57,7 @@ var helpers = {
     var slideWidth;
 
     if (!props.vertical) {
-      var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
-      slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj)/props.slidesToShow;
+      slideWidth = Math.ceil(listWidth / props.slidesToShow);
     } else {
       slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
     }
@@ -94,10 +92,16 @@ var helpers = {
     });
   },
   getWidth: function getWidth(elem) {
-    return elem.getBoundingClientRect().width || elem.offsetWidth;
+    var styles = window.getComputedStyle(elem);
+    var padding = parseFloat(styles.paddingLeft) + parseFloat(styles.paddingRight);
+
+    return elem.clientWidth - padding;
   },
-  getHeight(elem) {
-    return elem.getBoundingClientRect().height || elem.offsetHeight;
+  getHeight: function getHeight(elem) {
+    var styles = window.getComputedStyle(elem);
+    var padding = parseFloat(styles.paddingTop) + parseFloat(styles.paddingBottom);
+
+    return elem.clientHeight - padding;
   },
   adaptHeight: function () {
     if (this.props.adaptiveHeight) {


### PR DESCRIPTION
This fixes the issue mentioned in #566 that non-px values (e.g. `'20%'`) for `centerPadding` option don't work correctly in the latest version. It uses a similar approach to the original slick carousel, where the width of a slide element is based on the content width (i.e. it doesn't include padding widths) of the list element *after* applying the padding defined by `centerPadding` option.

Here's a demo of the broken version: https://jsfiddle.net/4cnuhvqm
Here's a demo of the fixed version:  https://jsfiddle.net/xrh8zuxm/