### PR TITLE
Fix slide popping up in infinite + centerMode

### DIFF
--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -115,7 +115,7 @@ export var getTrackLeft = function (spec) {
 
   if (spec.centerMode) {
     if(spec.infinite) {
-      slideOffset += spec.slideWidth * Math.floor(spec.slidesToShow / 2);
+      slideOffset += spec.slideWidth * Math.floor(spec.slidesToShow / 2) -  spec.slideWidth;
     } else {
       slideOffset = spec.slideWidth * Math.floor(spec.slidesToShow / 2);
     }

--- a/src/track.js
+++ b/src/track.js
@@ -62,7 +62,6 @@ var renderSlides = function (spec) {
   var postCloneSlides = [];
   var count = React.Children.count(spec.children);
 
-
   React.Children.forEach(spec.children, (elem, index) => {
     let child;
     var childOnClickOptions = {
@@ -105,7 +104,13 @@ var renderSlides = function (spec) {
 
     // variableWidth doesn't wrap properly.
     if (spec.infinite && spec.fade === false) {
-      var infiniteCount = spec.variableWidth ? spec.slidesToShow + 1 : spec.slidesToShow;
+      var infiniteCount;
+
+      if (spec.centerMode || spec.variableWidth) {
+        infiniteCount = spec.slidesToShow + 1;
+      } else {
+        infiniteCount = spec.slidesToShow;
+      }
 
       if (index >= (count - infiniteCount)) {
         key = -(count - index);


### PR DESCRIPTION
It fixes the issue mentioned in #557. 

It's based on the original code from slick carousel (and @MikeJSX PR https://github.com/akiran/react-slick/pull/565, but it fixes the issue where adding one more cloned slide, caused all slides to be incorrectly offset by 1).

Here's a demo of the broken version: https://jsfiddle.net/30rnf9kn/ (just move slides a few times in the same direction to see the issue)
Here's a demo of the fixed version: https://jsfiddle.net/094o7tcz/