### PR TITLE
Adds fallback 0 to getWidth and getHeight in case of undefined.

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -94,10 +94,10 @@ var helpers = {
     });
   },
   getWidth: function getWidth(elem) {
-    return elem.getBoundingClientRect().width || elem.offsetWidth;
+    return elem.getBoundingClientRect().width || elem.offsetWidth || 0;
   },
   getHeight(elem) {
-    return elem.getBoundingClientRect().height || elem.offsetHeight;
+    return elem.getBoundingClientRect().height || elem.offsetHeight || 0;
   },
   adaptHeight: function () {
     if (this.props.adaptiveHeight) {


### PR DESCRIPTION
We are using react-slick for an image carousel and our mocha tests are throwing random NaN console.logs:
```
Warning: `NaN` is an invalid value for the `width` css style property. Check the render method of `ProductDetailImage`.
```

Our tests are not currently failing, but we would like this message to disappear.

We've narrowed it down to the **getWidth** and **getHeight** functions returning undefined because our test images are mocked.

**elem.getBoundingClientRect().width** and **elem.getBoundingClientRect().height** are returning 0, but falling back to **elem.offsetWidth** and **elem.offsetHeight** which are returning undefined. We felt this should fallback to 0 in that case.