### PR TITLE
Fix pauseOnHover never trigger again

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -210,7 +210,12 @@ export var InnerSlider = React.createClass({
     const listStyle = assign({}, verticalHeightStyle, centerPaddingStyle);
 
     return (
-      <div className={className} onMouseEnter={this.onInnerSliderEnter} onMouseLeave={this.onInnerSliderLeave}>
+      <div
+        className={className}
+        onMouseEnter={this.onInnerSliderEnter}
+        onMouseLeave={this.onInnerSliderLeave}
+        onMouseOver={this.onInnerSliderOver}
+      >
         {prevArrow}
         <div
           ref={this.listRefHandler}

--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -41,7 +41,7 @@ var EventHandlers = {
 
     this.slideHandler(targetSlide);
   },
- 
+
   // Accessiblity handler for previous and next
   keyHandler: function (e) {
     //Dont slide if the cursor is inside the form fields and arrow keys are pressed
@@ -300,6 +300,11 @@ var EventHandlers = {
     }
   },
   onInnerSliderEnter: function (e) {
+    if (this.props.autoplay && this.props.pauseOnHover) {
+      this.pause();
+    }
+  },
+  onInnerSliderOver: function (e) {
     if (this.props.autoplay && this.props.pauseOnHover) {
       this.pause();
     }


### PR DESCRIPTION
When switch slider by clicking dots inside Slider container, the mouse enter will never trigger, so even the mouse point is still stay inside Slider container, the Slider won't stop.

demo: https://ant.design/components/carousel/#components-carousel-demo-autoplay

close ant-design/ant-design#4272