### PR TITLE
Add beforeSlick, beforeUnslick callbacks

### DIFF
--- a/examples/Responsive.js
+++ b/examples/Responsive.js
@@ -10,28 +10,42 @@ export default class Responsive extends Component {
       slidesToShow: 4,
       slidesToScroll: 4,
       initialSlide: 0,
-      responsive: [{
-        breakpoint: 1024,
-        settings: {
-          slidesToShow: 3,
-          slidesToScroll: 3,
-          infinite: true,
-          dots: true
+      beforeSlick: () => {
+        console.log('beforeSlick()');
+      },
+      beforeUnslick: () => {
+        console.log('beforeUnslick()');
+      },
+      responsive: [
+        {
+          breakpoint: 480,
+          settings: {
+            slidesToShow: 1,
+            slidesToScroll: 1
+          }
+        },
+        {
+          breakpoint: 600,
+          settings: {
+            slidesToShow: 2,
+            slidesToScroll: 2,
+            initialSlide: 2
+          }
+        },
+        {
+          breakpoint: 1024,
+          settings: {
+            slidesToShow: 3,
+            slidesToScroll: 3,
+            infinite: true,
+            dots: true
+          }
+        },
+        {
+          breakpoint: 5000,
+          settings: 'unslick'
         }
-      }, {
-        breakpoint: 600,
-        settings: {
-          slidesToShow: 2,
-          slidesToScroll: 2,
-          initialSlide: 2
-        }
-      }, {
-        breakpoint: 480,
-        settings: {
-          slidesToShow: 1,
-          slidesToScroll: 1
-        }
-      }]
+      ]
     };
     return (
       <div>

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -40,6 +40,8 @@ var defaultProps = {
     waitForAnimate: true,
     afterChange: null,
     beforeChange: null,
+    beforeSlick: null,
+    beforeUnslick: null,
     edgeEvent: null,
     init: null,
     swipeEvent: null,

--- a/src/slider.js
+++ b/src/slider.js
@@ -7,6 +7,8 @@ import json2mq from 'json2mq';
 import ResponsiveMixin from 'react-responsive-mixin';
 import defaultProps from './default-props';
 
+var isFunction = f => typeof f === 'function';
+
 var Slider = React.createClass({
   mixins: [ResponsiveMixin],
   innerSlider: null,
@@ -61,7 +63,7 @@ var Slider = React.createClass({
     var newProps;
     if (this.state.breakpoint) {
       newProps = this.props.responsive.filter(resp => resp.breakpoint === this.state.breakpoint);
-      settings = newProps[0].settings === 'unslick' ? 'unslick' : assign({}, this.props, newProps[0].settings);
+      settings = newProps[0].settings === 'unslick' ? 'unslick' : assign({}, defaultProps, this.props, newProps[0].settings);
     } else {
       settings = assign({}, defaultProps, this.props);
     }
@@ -78,10 +80,18 @@ var Slider = React.createClass({
 
     if (settings === 'unslick') {
       // if 'unslick' responsive breakpoint setting used, just return the <Slider> tag nested HTML
+      if (isFunction(this.props.beforeUnslick)) {
+        this.props.beforeUnslick();
+      }
+
       return (
         <div>{children}</div>
       );
     } else {
+      if (isFunction(this.props.beforeSlick)) {
+        this.props.beforeSlick();
+      }
+
       return (
         <InnerSlider ref={this.innerSliderRefHandler} {...settings}>
           {children}


### PR DESCRIPTION
Hey,
I'm building small wrapper around `react-slick` and I've needed a callback when unslick is done.
I added `beforeUnslick` and `beforeSlick`. Feel free to propose different names for callbacks.
I was trying to pick something that will be fit into the current naming like: `beforeChange`. `afterChange`.

I fixed also small difference when `unslick` is set and how `settings` are created.