### PR TITLE
Pass currentSlide and slideCount props to arrow components

### DIFF
--- a/src/arrows.js
+++ b/src/arrows.js
@@ -23,6 +23,8 @@ export var PrevArrow = React.createClass({
       key: '0',
       'data-role': 'none',
       className: classnames(prevClasses),
+      currentSlide: this.props.currentSlide,
+      slideCount: this.props.slideCount,
       style: {display: 'block'},
       onClick: prevHandler
     };
@@ -57,6 +59,8 @@ export var NextArrow = React.createClass({
       key: '1',
       'data-role': 'none',
       className: classnames(nextClasses),
+      currentSlide: this.props.currentSlide,
+      slideCount: this.props.slideCount,
       style: {display: 'block'},
       onClick: nextHandler
     };


### PR DESCRIPTION
My use case for this was to change the last slide's arrow from saying "Next" to "Done". The default arrows have access to these props and use them to set a disabled class. It seems only fair that custom arrows have these props as well 😄 .

I found it difficult to use the `beforeChange` handler alone to achieve this without causing the entire carousel to re-render. That was bad because it prevented the slide transitions from animating.