### PR TITLE
Handle edge cases and catch errors

### DIFF
--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -226,7 +226,13 @@ var EventHandlers = {
         return true;
       });
 
-      const slidesTraversed = Math.abs(swipedSlide.dataset.index - this.state.currentSlide) || 1;
+      var slidesTraversed;
+
+      try {
+        slidesTraversed = Math.abs(swipedSlide.dataset.index);
+      } catch (e) {
+        slidesTraversed = 1;
+      }
 
       return slidesTraversed;
     } else {

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -138,7 +138,12 @@ export var getTrackLeft = function (spec) {
       targetLeft = targetSlide ? targetSlide.offsetLeft * -1 : 0;
       if (spec.centerMode === true) {
           if(spec.infinite === false) {
-              targetSlide = ReactDOM.findDOMNode(spec.trackRef).children[spec.slideIndex];
+              if (spec.slideIndex === spec.slideCount || spec.slideIndex < 0) {
+                // Dont throw exception on edge cases
+                targetSlide = _reactDom2.default.findDOMNode(spec.trackRef).children[spec.slideIndex-1] || _reactDom2.default.findDOMNode(spec.trackRef).children[0];
+              } else {
+                targetSlide = _reactDom2.default.findDOMNode(spec.trackRef).children[spec.slideIndex];
+              }
           } else {
               targetSlide = ReactDOM.findDOMNode(spec.trackRef).children[(spec.slideIndex + spec.slidesToShow + 1)];
           }


### PR DESCRIPTION
This patch prevents slider from trying to scroll out of boundaries and cause offset errors. This behaviour happened with following settings: 

```
let settings = {
            infinite: false,
            slidesToScroll: 1,
            swipeToSlide: false, // Also with true
            centerMode: true
        };
```

This patch allows slider to snap back to previous slide if it run out of slides. 
Also added correct error handling for cases when 'swipeToSlide' enabled, however it still does not work too well and needs further refactoring. 

This patch should solve issue #534 and #357 and maybe other related issues too.

Please merge and publish as soon as possible, we are using it in production. 

Thank you!