### PR TITLE
Fix JS error when swipeToSlide but finite slide

### DIFF
--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -226,6 +226,10 @@ var EventHandlers = {
         return true;
       });
 
+      if (!swipedSlide) {
+          return 0;
+      }
+
       const slidesTraversed = Math.abs(swipedSlide.dataset.index - this.state.currentSlide) || 1;
 
       return slidesTraversed;


### PR DESCRIPTION
If you create a finite free swipable carousel, and try to scroll further the extremum slide, a JS error occurs:

> event-handlers.js:250 Uncaught TypeError: Cannot read property 'dataset' of undefined(…)

This PR fixes it. There is no tests, as I was unsuccessful to test a mix-in, even by trying to create a dummy element to deal with it. If you get some clue, I would be happy to add some. :)