### PR TITLE
Remove `parseInt` from `changeSlide` index method

### DIFF
--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -33,7 +33,7 @@ var EventHandlers = {
         return;
       }
     } else if (options.message === 'index') {
-      targetSlide = parseInt(options.index);
+      targetSlide = options.index;
       if (targetSlide === options.currentSlide) {
         return;
       }


### PR DESCRIPTION
`slidesToScroll` option allows non-integer (fractional) values.

Why restrict `slickGoTo` to only integers?

Edit: Just occurred to me, some folks may be passing strings into `slickGoTo`. In that case, how about using `parseFloat` instead of `parseInt`?