### PR TITLE
Fix getHeight and getWidth erroring when no slides exist

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -94,10 +94,10 @@ var helpers = {
     });
   },
   getWidth: function getWidth(elem) {
-    return elem.getBoundingClientRect().width || elem.offsetWidth || 0;
+    return elem && (elem.getBoundingClientRect().width || elem.offsetWidth) || 0;
   },
   getHeight(elem) {
-    return elem.getBoundingClientRect().height || elem.offsetHeight || 0;
+    return elem && (elem.getBoundingClientRect().height || elem.offsetHeight) || 0;
   },
   adaptHeight: function () {
     if (this.props.adaptiveHeight) {


### PR DESCRIPTION
The `getHeight` and `getWidth` helpers will throw an error if no slides are present. The element passed into these helpers is the result of [a querySelector](https://github.com/akiran/react-slick/blob/8c3652b727bccb1ad75bf376cdcaaf93100b7b5b/src/mixins/helpers.js#L24) with no result (`null`).