### PR TITLE
Fixed animation timeout IDs never getting set/cleared

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -174,7 +174,7 @@ var helpers = {
       this.setState({
         animating: true,
         currentSlide: targetSlide
-      }, function () {
+      }, () => {
         this.animationEndCallback = setTimeout(callback, this.props.speed);
       });
 
@@ -278,7 +278,7 @@ var helpers = {
         animating: true,
         currentSlide: currentSlide,
         trackStyle: getTrackAnimateCSS(assign({left: targetLeft}, this.props, this.state))
-      }, function () {
+      }, () => {
         this.animationEndCallback = setTimeout(callback, this.props.speed);
       });
 


### PR DESCRIPTION
The animation changes in #125 forgot to include the arrow function changes. Thus, the callback ID never gets set on the correct context. This can lead to `setState` getting called after the component has been unmounted.