### PR TITLE
Hotfix/arrow props cleanup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,5 @@
     "react",
     ["es2015", {"loose": true}]
   ],
-  "plugins": ["transform-object-assign"]
+  "plugins": ["transform-object-assign", "transform-object-rest-spread"]
 }

--- a/__tests__/arrows.js
+++ b/__tests__/arrows.js
@@ -1,0 +1,37 @@
+/**
+ * Arrow component tests
+ */
+
+sinon.stub(console, 'error');
+
+import {shallow} from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+
+import { NextArrow, PrevArrow } from '../src/arrows';
+
+describe('Previous arrows', () => {
+  it('should render arrow', () => {
+    const wrapper = shallow(<PrevArrow />);
+    expect(wrapper.find('button')).toHaveLength(1);
+  });
+
+  it('should not result in errors', () => {
+    shallow(<PrevArrow />);
+
+    expect(console.error.called).toBe(false);
+  });
+});
+
+describe('Next arrows', () => {
+  it('should render arrow', () => {
+    const wrapper = shallow(<NextArrow />);
+    expect(wrapper.find('button')).toHaveLength(1);
+  });
+
+  it('should not result in errors', () => {
+    shallow(<NextArrow />);
+
+    expect(console.error.called).toBe(false);
+  });
+});

--- a/__tests__/arrows.js
+++ b/__tests__/arrows.js
@@ -4,11 +4,17 @@
 
 sinon.stub(console, 'error');
 
-import {shallow} from 'enzyme';
+import {render, shallow} from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
 
 import { NextArrow, PrevArrow } from '../src/arrows';
+
+let CustomArrow = React.createClass({
+  render: function () {
+    return <span className="sample" data-currentSlide={this.props.currentSlide} data-slideCount={this.props.slideCount} />;
+  }
+})
 
 describe('Previous arrows', () => {
   it('should render arrow', () => {
@@ -20,6 +26,17 @@ describe('Previous arrows', () => {
     shallow(<PrevArrow />);
 
     expect(console.error.called).toBe(false);
+  });
+
+  it('should pass slide data to custom arrow', () => {
+    let elAttributes;
+    let arr = <CustomArrow />
+
+    const wrapper = render(<PrevArrow currentSlide={3} prevArrow={arr} slideCount={5} />);
+
+    elAttributes = wrapper.find('.sample')[0].attribs;
+    expect(elAttributes['data-currentslide']).toBe('3');
+    expect(elAttributes['data-slidecount']).toBe('5');
   });
 });
 
@@ -33,5 +50,16 @@ describe('Next arrows', () => {
     shallow(<NextArrow />);
 
     expect(console.error.called).toBe(false);
+  });
+
+  it('should pass slide data to custom arrow', () => {
+    let elAttributes;
+    let arr = <CustomArrow />
+
+    const wrapper = render(<NextArrow currentSlide={6} nextArrow={arr} slideCount={9} />);
+
+    elAttributes = wrapper.find('.sample')[0].attribs;
+    expect(elAttributes['data-currentslide']).toBe('6');
+    expect(elAttributes['data-slidecount']).toBe('9');
   });
 });

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import Slider from '../src/index';
+
+describe('Slider', function() {
+  it('should render', function() {
+    const wrapper = shallow(<Slider><div>slide1</div></Slider>);
+    expect(wrapper.contains(<div>slide1</div>)).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp": "^3.9.1",
     "gulp-sass": "^2.3.2",
     "jasmine-core": "^2.5.2",
-    "jest": "^15.1.1",
+    "jest": "^19.0.2",
     "json-loader": "^0.5.4",
     "node-sass": "^3.10.1",
     "postcss-loader": "^0.13.0",
@@ -74,7 +74,9 @@
     "react-dom": "^0.14.0 || ^15.0.1"
   },
   "jest": {
-    "setupFiles": ["test-setup.js"]
+    "setupFiles": [
+      "./test-setup.js"
+    ]
   },
   "npmName": "react-slick",
   "npmFileMap": [

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-dom": "^15.3.2",
     "run-sequence": "^1.2.2",
     "sass-loader": "^4.0.2",
+    "sinon": "^1.17.7",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.16.1"

--- a/src/arrows.js
+++ b/src/arrows.js
@@ -23,8 +23,6 @@ export var PrevArrow = React.createClass({
       key: '0',
       'data-role': 'none',
       className: classnames(prevClasses),
-      currentSlide: this.props.currentSlide,
-      slideCount: this.props.slideCount,
       style: {display: 'block'},
       onClick: prevHandler
     };
@@ -59,8 +57,6 @@ export var NextArrow = React.createClass({
       key: '1',
       'data-role': 'none',
       className: classnames(nextClasses),
-      currentSlide: this.props.currentSlide,
-      slideCount: this.props.slideCount,
       style: {display: 'block'},
       onClick: nextHandler
     };

--- a/src/arrows.js
+++ b/src/arrows.js
@@ -26,10 +26,14 @@ export var PrevArrow = React.createClass({
       style: {display: 'block'},
       onClick: prevHandler
     };
+    var customProps = {
+      currentSlide: this.props.currentSlide,
+      slideCount: this.props.slideCount
+    };
     var prevArrow;
 
     if (this.props.prevArrow) {
-      prevArrow = React.cloneElement(this.props.prevArrow, prevArrowProps);
+      prevArrow = React.cloneElement(this.props.prevArrow, { ...prevArrowProps, ...customProps });
     } else {
       prevArrow = <button key='0' type='button' {...prevArrowProps}> Previous</button>;
     }
@@ -60,11 +64,14 @@ export var NextArrow = React.createClass({
       style: {display: 'block'},
       onClick: nextHandler
     };
-
+    var customProps = {
+      currentSlide: this.props.currentSlide,
+      slideCount: this.props.slideCount
+    };
     var nextArrow;
 
     if (this.props.nextArrow) {
-      nextArrow = React.cloneElement(this.props.nextArrow, nextArrowProps);
+      nextArrow = React.cloneElement(this.props.nextArrow, { ...nextArrowProps, ...customProps });
     } else {
       nextArrow = <button key='1' type='button' {...nextArrowProps}> Next</button>;
     }


### PR DESCRIPTION
I've cleaned up the arrow elements and left the custom props in for custom arrows.

I didn't see any use for them on the standard buttons.

This should fix issue #623.