### PR TITLE
Fix for custom arrows example issue

### DIFF
--- a/examples/CustomArrows.js
+++ b/examples/CustomArrows.js
@@ -1,19 +1,24 @@
 import React, { Component } from 'react'
 import Slider from '../src/slider'
 
-var SampleNextArrow = React.createClass({
-  render: function() {
-    return <div {...this.props} style={{display: 'block', background: 'red'}}></div>;
-  }
-});
+class CarouselArrow extends Component {
 
-var SamplePrevArrow = React.createClass({
-  render: function() {
+  render() {
+    let style = {
+      ...this.props.style,
+      display: 'block',
+      background: '#d8e4e8',
+      'paddingLeft': '6px',
+    };
+
     return (
-      <div {...this.props} style={{display: 'block', background: 'red'}}></div>
+      <div className={this.props.className}
+           onClick={this.props.onClick}
+           style={style}>
+      </div>
     );
   }
-});
+}
 
 export default class CustomArrows extends Component {
   render() {
@@ -22,8 +27,8 @@ export default class CustomArrows extends Component {
       infinite: true,
       slidesToShow: 3,
       slidesToScroll: 1,
-      nextArrow: <SampleNextArrow />,
-      prevArrow: <SamplePrevArrow />
+      nextArrow: <CarouselArrow />,
+      prevArrow: <CarouselArrow />
     };
     return (
       <div>


### PR DESCRIPTION
This PR provides a fix for issue: https://github.com/akiran/react-slick/issues/671

---

**Version:** 0.14.7
**Related ticket:** https://github.com/akiran/react-slick/issues/623

**Error:**

```
Warning: Unknown props `currentSlide`, `slideCount` on <div> tag. Remove these props from the element. For details, see https://fb.me/react-unknown-prop
    in div (created by Carousel)
    in PrevArrow (created by InnerSlider)
    in div (created by InnerSlider)
    in InnerSlider (created by Slider)
    in Slider (created by Carousel)
```

This happens when using the official example for custom arrows: [link](https://github.com/akiran/react-slick/blob/master/examples/CustomArrows.js)

Even though the original ticket was for veresion 0.14.6, this is still happening to me in version 0.14.7.

I fixed it by carefully handling the props on the div (only passing it the props that it can receive) used to render the button and worked like a charm.

This way:

```javascript
class CarouselArrow extends Component {

  render() {
    let style = {
      ...this.props.style,
      display: 'block',
      background: '#d8e4e8',
      'paddingLeft': '6px',
    };

    return (
      <div className={this.props.className}
              onClick={this.props.onClick}
              style={style}>
      </div>
    );
  }
}
```