### PR TITLE
Center Padding Accepts %

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "devDependencies": {
     "autoprefixer-core": "^6.0.1",
-    "babel-cli": "^6.16.0",
+    "babel-cli": "^6.24.0",
     "babel-core": "^6.16.0",
     "babel-eslint": "^7.0.0",
     "babel-jest": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "prepublish": "babel ./src --out-dir ./lib && gulp dist",
     "test": "jest",
     "dev-test": "jest --watch",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "install": "npm run prepublish"
   },
   "author": "Kiran Abburi",
   "license": "MIT",

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -16,6 +16,9 @@ var helpers = {
 
     if (!props.vertical) {
       var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
+      if (props.centerPadding.slice(-1) === '%') {
+        centerPaddingAdj *= listWidth / 100
+      }
       slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj)/props.slidesToShow;
     } else {
       slideWidth = this.getWidth(ReactDOM.findDOMNode(this));


### PR DESCRIPTION
I found a bug where you could not set centerPadding by percent.  Fix involves looking for % sign and calculating the percent in px of parent, rather than just using parseInt(centerPadding) as px.