### PR TITLE
Fix for Bug in Slide Position while Using Fade and Swipe

### DIFF
--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -30,27 +30,27 @@ export var getTrackCSS = function(spec) {
   }
 
     var style = {
-        opacity: 1,
+      opacity: 1,
     };
 
     var transform = {
-        WebkitTransform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
-        transform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
-        transition: '',
-        WebkitTransition: '',
-        msTransform: !spec.vertical ? 'translateX(' + spec.left + 'px)' : 'translateY(' + spec.left + 'px)',
+      WebkitTransform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
+      transform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
+      transition: '',
+      WebkitTransition: '',
+      msTransform: !spec.vertical ? 'translateX(' + spec.left + 'px)' : 'translateY(' + spec.left + 'px)',
     };
 
     if (trackWidth) {
-        assign(style, { width: trackWidth });
+      assign(style, { width: trackWidth });
     }
 
     if (trackHeight) {
-        assign(style, { height: trackHeight });
+      assign(style, { height: trackHeight });
     }
 
     if (!spec.fade) {
-        assign(style, transform);
+      assign(style, transform);
     }
 
   // Fallback for IE8

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -29,22 +29,29 @@ export var getTrackCSS = function(spec) {
     trackHeight = trackChildren * spec.slideHeight;
   }
 
-  var style = {
-    opacity: 1,
-    WebkitTransform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
-    transform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
-    transition: '',
-    WebkitTransition: '',
-    msTransform: !spec.vertical ? 'translateX(' + spec.left + 'px)' : 'translateY(' + spec.left + 'px)',
-  };
+    var style = {
+        opacity: 1,
+    };
 
-  if (trackWidth) {
-    assign(style, { width: trackWidth });
-  }
+    var transform = {
+        WebkitTransform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
+        transform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
+        transition: '',
+        WebkitTransition: '',
+        msTransform: !spec.vertical ? 'translateX(' + spec.left + 'px)' : 'translateY(' + spec.left + 'px)',
+    };
 
-  if (trackHeight) {
-    assign(style, { height: trackHeight });
-  }
+    if (trackWidth) {
+        assign(style, { width: trackWidth });
+    }
+
+    if (trackHeight) {
+        assign(style, { height: trackHeight });
+    }
+
+    if (!spec.fade) {
+        assign(style, transform);
+    }
 
   // Fallback for IE8
   if (window && !window.addEventListener && window.attachEvent) {

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -29,29 +29,29 @@ export var getTrackCSS = function(spec) {
     trackHeight = trackChildren * spec.slideHeight;
   }
 
-    var style = {
-      opacity: 1,
-    };
+  var style = {
+    opacity: 1,
+  };
 
-    var transform = {
-      WebkitTransform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
-      transform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
-      transition: '',
-      WebkitTransition: '',
-      msTransform: !spec.vertical ? 'translateX(' + spec.left + 'px)' : 'translateY(' + spec.left + 'px)',
-    };
+  var transform = {
+    WebkitTransform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
+    transform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
+    transition: '',
+    WebkitTransition: '',
+    msTransform: !spec.vertical ? 'translateX(' + spec.left + 'px)' : 'translateY(' + spec.left + 'px)',
+  };
 
-    if (trackWidth) {
-      assign(style, { width: trackWidth });
-    }
+  if (trackWidth) {
+    assign(style, { width: trackWidth });
+  }
 
-    if (trackHeight) {
-      assign(style, { height: trackHeight });
-    }
+  if (trackHeight) {
+    assign(style, { height: trackHeight });
+  }
 
-    if (!spec.fade) {
-      assign(style, transform);
-    }
+  if (!spec.fade) {
+    assign(style, transform);
+  }
 
   // Fallback for IE8
   if (window && !window.addEventListener && window.attachEvent) {


### PR DESCRIPTION
Currently, the library does not support the use of fade animation while swipe is enabled.  Using both of these results in slide positioning bugs (as documented https://github.com/akiran/react-slick/issues/585 and https://github.com/akiran/react-slick/issues/603).

I have fixed the bug by only applying the transforms if fade is not active (slide should move across the screen while swiping).