### PR TITLE
fix edge drag case

### DIFF
--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -144,6 +144,10 @@ var EventHandlers = {
     if (this.props.verticalSwiping) {
       swipeLeft = curLeft + touchSwipeLength * positionOffset;
     }
+    
+    if (!(this.props.verticalSwiping || this.props.vertical) && swipeDirection === 'vertical' && swipeLeft) {
+      swipeLeft = curLeft;
+    }
 
     this.setState({
       touchObject: touchObject,


### PR DESCRIPTION
this prevents edgedrag when scrolling vertically but slightly right/left
swipeDirection is "vertical" because of angle (see swipeDirection) so above edgeDrag protection doesn't work 
in this case just leave swipeLeft at same position