### PR TITLE
Center Padding Should Accept Percentage Values

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -16,6 +16,9 @@ var helpers = {
 
     if (!props.vertical) {
       var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
+      if (props.centerPadding.slice(-1) === '%') {
+        centerPaddingAdj *= listWidth / 100
+      }
       slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj)/props.slidesToShow;
     } else {
       slideWidth = this.getWidth(ReactDOM.findDOMNode(this));

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -62,6 +62,9 @@ var helpers = {
 
     if (!props.vertical) {
       var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
+      if (props.centerPadding.slice(-1) === '%') {
+        centerPaddingAdj *= listWidth / 100
+      }
       slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj)/props.slidesToShow;
     } else {
       slideWidth = this.getWidth(ReactDOM.findDOMNode(this));


### PR DESCRIPTION
Center Padding currently uses parseInt to convert values to numbers, assuming it is a pixel value.  This change checks if it is a percentage value, and if so, calculates the percentage of the width it represents in pixels and adjusts accordingly