### PR TITLE
Animating state cleared when updating

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -74,6 +74,15 @@ var helpers = {
       this.autoPlay();
     }
 
+    // animating state should be cleared when updating, otherwise tracker width gets old value
+    if (this.animationEndCallback) {
+      this.setState({
+        animating: false
+      });
+      clearTimeout(this.animationEndCallback);
+      delete this.animationEndCallback;
+    }
+
     this.setState({
       slideCount,
       slideWidth,


### PR DESCRIPTION
Tracker gets an outdated width when the callback arrives after an update, it gets the old value.