### PR TITLE
Move enquire.js to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "css-loader": "^0.25.0",
     "deepmerge": "^1.1.0",
     "del": "^2.2.2",
-    "enquire.js": "^2.1.6",
     "enzyme": "^2.4.1",
     "es5-shim": "^4.5.9",
     "eslint": "^3.6.1",
@@ -66,6 +65,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "create-react-class": "^15.5.2",
+    "enquire.js": "^2.1.6",
     "json2mq": "^0.2.0",
     "object-assign": "^4.1.0",
     "slick-carousel": "^1.6.0"


### PR DESCRIPTION
Looks like b798b1fbd0aa50c73b3c0a2b506b7a27a3f40f31 introduced enquire.js, but added it to devDependencies instead of dependencies.

I noticed this when trying to build react-slick into my own project and the build started failing at 0.14.9.