### PR TITLE
Push correct slide number when lazy loading

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -229,9 +229,10 @@ var helpers = {
       var loaded = true;
       var slidesToLoad = [];
       for (var i = targetSlide; i < targetSlide + this.props.slidesToShow; i++ ) {
-        loaded = loaded && (this.state.lazyLoadedList.indexOf(i) >= 0);
+        var slideToLoad = i < 0 ? this.props.slideCount - i : i;
+        loaded = loaded && (this.state.lazyLoadedList.indexOf(slideToLoad) >= 0);
         if (!loaded) {
-          slidesToLoad.push(i);
+          slidesToLoad.push(slideToLoad);
         }
       }
       if (!loaded) {


### PR DESCRIPTION
This commit will push the correct slide number on to the `lazyLoadedList` when swiping right on the first slide. Before this commit it would push `-1` instead of the correct slide number.

This PR is different than #635 in that it pushes the correct the index to the `lazyLoadedList`.
#635 just handles having the wrong index on the `lazyLoadedList`

fixes #628