### PR TITLE
Issue fix TypeError: null is not an object (evaluating 'elem.getBoundingClientRect')

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -21,7 +21,7 @@ var helpers = {
       slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
     }
 
-    const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));
+    const slideHeight = this.getHeight(slickList.querySelector('.slick-track'));
     const listHeight = slideHeight * props.slidesToShow;
 
     var currentSlide = props.rtl ? slideCount - 1 - props.initialSlide : props.initialSlide;
@@ -64,7 +64,7 @@ var helpers = {
       slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
     }
 
-    const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));
+    const slideHeight = this.getHeight(slickList.querySelector('.slick-track'));
     const listHeight = slideHeight * props.slidesToShow;
 
     // pause slider if autoplay is set to false


### PR DESCRIPTION
issue fixed for TypeError: null is not an object (evaluating 'elem.getBoundingClientRect')
#712 