### PR TITLE
changed children length to account for child arrays

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -80,6 +80,14 @@ export var InnerSlider = createReactClass({
     }
   },
   componentWillReceiveProps: function(nextProps) {
+    
+    let length = nextProps.children.length;
+    for(var i = 0; i < nextProps.children.length; i++){
+      if(Array.isArray(nextProps.children[i])){
+        length += nextProps.children[i].length - 1;
+      }
+    }
+
     if (this.props.slickGoTo != nextProps.slickGoTo) {
       if (process.env.NODE_ENV !== 'production') {
         console.warn('react-slick deprecation warning: slickGoTo prop is deprecated and it will be removed in next release. Use slickGoTo method instead')
@@ -89,7 +97,7 @@ export var InnerSlider = createReactClass({
           index: nextProps.slickGoTo,
           currentSlide: this.state.currentSlide
       });
-    } else if (this.state.currentSlide >= nextProps.children.length) {
+    } else if (this.state.currentSlide >= length) {
       this.update(nextProps);
       this.changeSlide({
           message: 'index',


### PR DESCRIPTION
hi, I really love this library! But I've been running into a bug where when the slider has more than two slides, and I perform slick next, on re-render, it will jump back to the second slide. After much hair-pulling, I realized it was because the `children.length` property was only 2 even though I had four child components. The first component was an array of length 3 (three slides) which were not accounted for. The reason for this was because I was using a map of three slides on the first element. i.e. 
```
<Slider ref={ref => this.slider=ref} {...settings}>

          {Tracks}

          <div>
            <DownloadDisplay hashtag={this.props.hashtag} />
          </div>

        </Slider>
```
 This change is just meant to account for maps of react elements... `let Tracks = keys.map((key, index) => {`.
Hope this helps! If not I would like to report the bug anyhow :)