### PR TITLE
Fix dot count when slidesToScroll < slidesToShow

### DIFF
--- a/src/dots.js
+++ b/src/dots.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 
 var getDotCount = function (spec) {
   var dots;
-  dots = Math.ceil(spec.slideCount / spec.slidesToScroll);
+  dots = Math.ceil((spec.slideCount - spec.slidesToShow)/spec.slidesToScroll) + 1;
   return dots;
 };
 
@@ -21,7 +21,8 @@ export class Dots extends React.Component {
 
     var dotCount = getDotCount({
       slideCount: this.props.slideCount,
-      slidesToScroll: this.props.slidesToScroll
+      slidesToScroll: this.props.slidesToScroll,
+      slidesToShow: this.props.slidesToShow
     });
 
     // Apply join & split to Array to pre-fill it for IE8


### PR DESCRIPTION
Whenever the `slidesToScroll` option is smaller than `slidesToShow`, the calculation of the dots failed and was showing too many.

Let me know what you think.