### PR TITLE
fix(dots): Fix dot count when slidesToScroll is smaller than slidesToShow

### DIFF
--- a/src/dots.js
+++ b/src/dots.js
@@ -3,9 +3,15 @@
 import React from 'react';
 import classnames from 'classnames';
 
-var getDotCount = function (spec) {
+var getDotCount = function getDotCount(spec) {
   var dots;
-  dots = Math.ceil(spec.slideCount / spec.slidesToScroll);
+
+  if (spec.infinite) {
+    dots = Math.ceil((spec.slideCount) / spec.slidesToScroll);
+  } else {
+    dots = Math.ceil((spec.slideCount - spec.slidesToShow) / spec.slidesToScroll) + 1;
+  }
+
   return dots;
 };
 
@@ -21,7 +27,9 @@ export class Dots extends React.Component {
 
     var dotCount = getDotCount({
       slideCount: this.props.slideCount,
-      slidesToScroll: this.props.slidesToScroll
+      slidesToScroll: this.props.slidesToScroll,
+      slidesToShow: this.props.slidesToShow,
+      infinite: this.props.infinite
     });
 
     // Apply join & split to Array to pre-fill it for IE8

--- a/src/dots.js
+++ b/src/dots.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import classnames from 'classnames';
 
-var getDotCount = function getDotCount(spec) {
+var getDotCount = function (spec) {
   var dots;
 
   if (spec.infinite) {
@@ -11,7 +11,7 @@ var getDotCount = function getDotCount(spec) {
   } else {
     dots = Math.ceil((spec.slideCount - spec.slidesToShow) / spec.slidesToScroll) + 1;
   }
-
+  
   return dots;
 };
 
@@ -27,9 +27,7 @@ export class Dots extends React.Component {
 
     var dotCount = getDotCount({
       slideCount: this.props.slideCount,
-      slidesToScroll: this.props.slidesToScroll,
-      slidesToShow: this.props.slidesToShow,
-      infinite: this.props.infinite
+      slidesToScroll: this.props.slidesToScroll
     });
 
     // Apply join & split to Array to pre-fill it for IE8

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -160,7 +160,8 @@ export var InnerSlider = createReactClass({
         slidesToScroll: this.props.slidesToScroll,
         clickHandler: this.changeSlide,
         children: this.props.children,
-        customPaging: this.props.customPaging
+        customPaging: this.props.customPaging,
+        infinite: this.props.infinite
       };
 
       dots = (<Dots {...dotProps} />);


### PR DESCRIPTION
When configuring react-slick with slidesToScroll property smaller than slidesToShow the total number of dots shown is not accurate. 

This is now fixed and works for both, infinite and finite slider.

I've tested slider with the following setup with even (6) and odd (5) number of slides:

`slidesToShow={3} slidesToScroll={1} infinite={false}`
`slidesToShow={3} slidesToScroll={1} infinite`
`slidesToShow={1} slidesToScroll={1} infinite={false}`
`slidesToShow={1} slidesToScroll={1} infinite`
`slidesToShow={3} slidesToScroll={2} infinite={false}`
`slidesToShow={3} slidesToScroll={2} infinite`

Please let me know what you think. I'm happy to provide additional information whenever needed.

