### PR TITLE
Added feature to set an amount of pages of the slider to be preloaded…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ class SimpleSlider extends React.Component {
 | infinite       | bool | should the gallery wrap around it's contents | Yes |
 | initialSlide   | int | which item should be the first to be displayed | Yes |
 | lazyLoad       | bool | Loads images or renders components on demands | Yes |
+| pagesToPreload | int  | Sets the amount of pages to preload when lazyLoad is active. WIll preload pages when the slider is loaded as well as the next button is clicked. | Yes |
 | pauseOnHover   | bool | prevents autoplay while hovering | Yes |
 | responsive     | array | Array of objects in the form of `{ breakpoint: int, settings: { ... } }` The breakpoint _int_ is the `maxWidth` so the settings will be applied when resolution is below this value. Breakpoints in the array should be ordered from smalles to greatest. Use 'unslick' in place of the settings object to disable rendering the carousel at that breakpoint. Example: `[ { breakpoint: 768, settings: { slidesToShow: 3 } }, { breakpoint: 1024, settings: { slidesToShow: 5 } }, { breakpoint: 100000, settings: 'unslick' } ]`| Yes |
 | rtl            | bool | Reverses the slide order | Yes |

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -45,7 +45,8 @@ var defaultProps = {
     swipeEvent: null,
     // nextArrow, prevArrow are react componets
     nextArrow: null,
-    prevArrow: null
+    prevArrow: null, 
+    pagesToPreload: 1
 };
 
 module.exports = defaultProps;

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -40,7 +40,7 @@ export var InnerSlider = createReactClass({
     });
     var lazyLoadedList = [];
     for (var i = 0; i < React.Children.count(this.props.children); i++) {
-      if (i >= this.state.currentSlide && i < this.state.currentSlide + this.props.slidesToShow) {
+      if (i >= this.state.currentSlide && i < this.state.currentSlide + (this.props.slidesToShow * this.props.pagesToPreload)) {
         lazyLoadedList.push(i);
       }
     }

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -228,7 +228,7 @@ var helpers = {
     if (this.props.lazyLoad) {
       var loaded = true;
       var slidesToLoad = [];
-      for (var i = targetSlide; i < targetSlide + this.props.slidesToShow; i++ ) {
+      for (var i = targetSlide; i < targetSlide + (this.props.slidesToShow * this.props.pagesToPreload); i++ ) {
         loaded = loaded && (this.state.lazyLoadedList.indexOf(i) >= 0);
         if (!loaded) {
           slidesToLoad.push(i);


### PR DESCRIPTION
…, when the component is loaded as well as the next button is clicked. It only works when lazyLoad is set to true.

Description: 

Often, I read about the need of the carousel to have the ability to preload the next page when the lazyLoad property is set to true. 

I added a property called pagesToPreload (default = 1) , wich represents the amount of pages of the carousel that are loaded on the inital loading of the component, as well as the next button is pressed.
Minimum changes to the code have been applied to achieve this feature. 

In this way, In the case when there are several images to show in several pages of a carousel, when one of the pages is lazy-loaded, the next page is preloaded. So when the user navigates to the next page, it's already loaded, therefore it will show faster. At the same time, the next page will be preloaded too.
This is could improve the user experience in terms of performance, for that use case.
