### PR TITLE
Prevent native swipe event during animation

### DIFF
--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -87,6 +87,7 @@ var EventHandlers = {
       return;
     }
     if (this.state.animating) {
+      e.preventDefault();
       return;
     }
     if (this.props.vertical && this.props.swipeToSlide && this.props.verticalSwiping) {


### PR DESCRIPTION
Call preventDefault during animation, otherwise it will trigger native swipe event, such as tab switch.