### PR TITLE
Added className to wrapper of destroyed slider

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -91,7 +91,9 @@ export default class Slider extends React.Component {
     if (settings === 'unslick') {
       // if 'unslick' responsive breakpoint setting used, just return the <Slider> tag nested HTML
       return (
-        <div>{children}</div>
+        <div className={`${this.props.className} unslicked`}>
+          {children}
+        </div>
       );
     } else {
       return (


### PR DESCRIPTION
1.  In some cases, it's necessary to add styles to wrapper of destroyed slider. It's better to add className to existing wrapper, than wrap it to another one and write something like:
```css 
.wrapper > div { display: flex; ... } 
```
2. To avoid duplication of responsive logic, it'll be easier to write:
```css 
.wrapper.unslicked { display: flex; ... } 
```