### PR TITLE
Add a warning sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Carousel component built with React. It is a react port of [slick carousel](http
 npm install react-slick
 ```
 
-Also install slick-carousel for css and font
+⚠️ Also install slick-carousel for css and font 
 
 ```bash
 npm install slick-carousel


### PR DESCRIPTION
Hey, many developers are used to running only ```npm install package-name``` to add a package. We were two developers to forget importing the styles and to get an unexpectedly broken slideshow.
(You might also consider adding a comment line in the JsFiddle to remind us to get the external css files imo)

It's a silly mistake but it can be very puzzling and made us waste 1 hour each !

I think this small warning can save time to people \o/ what do you think guys ?