### PR TITLE
slick carousel css uses UTF-8 encoding for the 'dots' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Carousel component built with React. It is a react port of [slick carousel](http
 npm install react-slick
 ```
 
-⚠️ Also install slick-carousel for css and font 
+⚠️ Also install slick-carousel for css and font
 
 ```bash
 npm install slick-carousel
@@ -24,7 +24,7 @@ npm install slick-carousel
 or add cdn link in your html
 
 ```html
-<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css" />
+<link rel="stylesheet" type="text/css" charset="UTF-8" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css" />
 <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css" />
 ```
 


### PR DESCRIPTION
Adding this `charset="UTF-8"` attribute on the link tag prevents the dots from breaking.