### PR TITLE
Added afterRender method

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ class SimpleSlider extends React.Component {
 | vertical | bool | Vertical slide mode | Yes |
 | afterChange | function | callback function called after the current index changes. The new index is accessible in the first parameter of the callback function. | Yes |
 | beforeChange | function | callback function called before the current index changes. The old and the new indexes are accessible in the first and the second parameters of the callback function respectively. | Yes |
+| afterRender | function | Exposes the entire slider object, including state, props and calculated properties of all elements after each calculation or change | Yes |
+
 | slickGoTo | int | go to the specified slide number | |
 
 

--- a/__tests__/afterRender.test.js
+++ b/__tests__/afterRender.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import Slider from '../src/index';
+
+class SliderWithAfterRender extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      wasAfterRenderCalled: 0
+    }
+    this.afterRender = this.afterRender.bind(this)
+  }
+  afterRender(slider) {
+    this.setState({
+      wasAfterRenderCalled: this.state.wasAfterRenderCalled+1
+    })
+  }
+  render() {
+    return (
+      <Slider afterRender={this.afterRender}>
+        <div>slide1</div>
+        <div>slide2</div>
+        <div>slide3</div>
+        <div>slide4</div>
+      </Slider>
+    )
+  }
+}
+
+describe('afterRender Hook', function() {
+  it('should be called after initialization', function() {
+    const wrapper = mount(<SliderWithAfterRender />);
+    // you can probably achieve the same with spies, kept the convention of the other tests
+    expect(wrapper.state().wasAfterRenderCalled).toEqual(1);
+  });
+
+  it('should be dispatched on resize', function() {
+    const wrapper = mount(<SliderWithAfterRender />);
+    window.dispatchEvent(new Event("resize", {cancellable: true, bubbles: true}))
+    window.dispatchEvent(new Event("resize", {cancellable: true, bubbles: true}))
+    expect(wrapper.state().wasAfterRenderCalled).toEqual(3);
+    
+    
+  })
+});

--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -27,6 +27,7 @@ import SwipeToSlide from '../examples/SwipeToSlide'
 import VerticalSwipeToSlide from '../examples/VerticalSwipeToSlide'
 import CustomPaging from '../examples/CustomPaging'
 import CustomSlides from '../examples/CustomSlides'
+import AfterRenderHook from '../examples/AfterRenderHook'
 
 export default class App extends React.Component {
   render() {
@@ -47,6 +48,7 @@ export default class App extends React.Component {
         <LazyLoad />
         <Fade />
         <SlideChangeHooks />
+        <AfterRenderHook />
         <SlickGoTo />
         <CustomPaging />
         <CustomArrows />

--- a/examples/AfterRenderHook.js
+++ b/examples/AfterRenderHook.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react'
+import Slider from '../src/slider'
+
+export default class SlideChangeHooks extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      called: 0
+    }
+    this.afterRender = this.afterRender.bind(this)    
+  }
+
+  afterRender(slider) {
+    this.setState({called: this.state.called+1}, () => console.log(this.state.called))
+  }
+  render() {
+    const settings = {
+      dots: true,
+      infinite: true,
+      speed: 500,
+      afterRender: this.afterRender,
+      slidesToShow: 1,
+      slidesToScroll: 1
+    };
+    return (
+      <div>
+        <h2>afterRender Hook</h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+          <div><h3>5</h3></div>
+          <div><h3>6</h3></div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "can-use-dom": "^0.1.0",
     "classnames": "^2.2.5",
     "create-react-class": "^15.5.2",
+    "deep-equal": "^1.0.1",
     "enquire.js": "^2.1.6",
     "json2mq": "^0.2.0",
     "object-assign": "^4.1.0",

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -12,6 +12,7 @@ import assign from 'object-assign';
 import { Track } from './track';
 import { Dots } from './dots';
 import { PrevArrow, NextArrow } from './arrows';
+import deepEqual from "deep-equal";
 
 export var InnerSlider = createReactClass({
   mixins: [HelpersMixin, EventHandlersMixin],
@@ -96,7 +97,7 @@ export var InnerSlider = createReactClass({
         index: nextProps.children.length - nextProps.slidesToShow,
         currentSlide: this.state.currentSlide
       });
-    } else {
+    } else if(!deepEqual(this.props, nextProps)) { //kinda expensive, but worth the extra feature, calling this.update() every time, basically, is extremely dangerous, due the risk of circular calls
       this.update(nextProps);
     }
   },

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -43,8 +43,8 @@ var helpers = {
       // getCSS function needs previously set state
       var trackStyle = getTrackCSS(assign({left: targetLeft}, props, this.state));
 
-      this.setState({trackStyle: trackStyle});
-
+      this.setState({trackStyle: trackStyle}, this.afterRender);
+      
       this.autoPlay(); // once we're set up, trigger the initial autoplay.
     });
   },
@@ -82,16 +82,33 @@ var helpers = {
       slideHeight,
       listHeight,
     }, function () {
-
       var targetLeft = getTrackLeft(assign({
         slideIndex: this.state.currentSlide,
         trackRef: this.track
       }, props, this.state));
       // getCSS function needs previously set state
-      var trackStyle = getTrackCSS(assign({left: targetLeft}, props, this.state));
-
-      this.setState({trackStyle: trackStyle});
+      var trackStyle = getTrackCSS(assign({left: targetLeft}, props, this.state));      
+      this.setState({trackStyle: trackStyle}, this.afterRender);
     });
+  },
+  afterRender: function() {
+    if(this.props.afterRender) {
+      if(typeof this.props.afterRender !== "function") {
+        throw Error("Error: afterRender must be a function")
+      } else {
+        // I'd like to make it possible to refer a different "this" in whoever's using it scope
+        // hence passing 'this' as a parameter, rather than binding to it.
+        this.props.afterRender(this);
+      }
+    }
+  },
+  afterRenderInit: function() {
+    // short-circuiting the function after a single invocation to prevent a maximum callstack exception
+    // this shuold be safe since initialization should only be invoked once and only draw information from props, rather than state, 
+    // the fact its not is a bug, IMO.
+    if(!this.state.afterRenderInitInvoked) {
+      this.setState({afterRenderInitInvoked: true}, this.afterRender)
+    }
   },
   getWidth: function getWidth(elem) {
     return elem && (elem.getBoundingClientRect().width || elem.offsetWidth) || 0;


### PR DESCRIPTION
The afterRender method method exposes the entire slider object, including state, props and calculated properties of all elements after each calculation or change.

type: function
parameters: sliderObject<ReactClass>

See newly added example and tests for details