### PR TITLE
Usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Carousel component built with React. It is a react port of [slick carousel](http
 npm install react-slick
 ```
 
-⚠️ Also install slick-carousel for css and font 
+⚠️ Also install slick-carousel for css and font
 
 ```bash
 npm install slick-carousel
@@ -76,8 +76,8 @@ class SimpleSlider extends React.Component {
 | className      | String |Additional class name for the inner slider div | Yes |
 | adaptiveHeight | bool | Adjust the slide's height automatically | Yes |
 | arrows         | bool | Should we show Left and right nav arrows | Yes |
-| nextArrow      | React Element | Use this element for the next arrow button [Example](https://github.com/akiran/react-slick/blob/master/examples/CustomArrows.js) | Yes |
-| prevArrow      | React Element | Use this element for the prev arrow button [Example](https://github.com/akiran/react-slick/blob/master/examples/CustomArrows.js) | Yes |
+| nextArrow      | React Component | Use this component for the next arrow button [Example](https://github.com/akiran/react-slick/blob/master/examples/CustomArrows.js) | Yes |
+| prevArrow      | React Component | Use this component for the prev arrow button [Example](https://github.com/akiran/react-slick/blob/master/examples/CustomArrows.js) | Yes |
 | autoplay       | bool | Should the scroller auto scroll? | Yes |
 | autoplaySpeed  |  int | delay between each auto scoll. in ms | Yes |
 | centerMode     | bool | Should we centre to a single item? | Yes |

--- a/__tests__/arrows.js
+++ b/__tests__/arrows.js
@@ -33,9 +33,8 @@ describe('Previous arrows', () => {
 
   it('should pass slide data to custom arrow', () => {
     let elAttributes;
-    let arr = <CustomArrow />
 
-    const wrapper = render(<PrevArrow currentSlide={3} prevArrow={arr} slideCount={5} />);
+    const wrapper = render(<PrevArrow currentSlide={3} prevArrow={CustomArrow} slideCount={5} />);
 
     elAttributes = wrapper.find('.sample')[0].attribs;
     expect(elAttributes['data-currentslide']).toBe('3');
@@ -57,9 +56,8 @@ describe('Next arrows', () => {
 
   it('should pass slide data to custom arrow', () => {
     let elAttributes;
-    let arr = <CustomArrow />
 
-    const wrapper = render(<NextArrow currentSlide={6} nextArrow={arr} slideCount={9} />);
+    const wrapper = render(<NextArrow currentSlide={6} nextArrow={CustomArrow} slideCount={9} />);
 
     elAttributes = wrapper.find('.sample')[0].attribs;
     expect(elAttributes['data-currentslide']).toBe('6');

--- a/examples/CustomArrows.js
+++ b/examples/CustomArrows.js
@@ -31,8 +31,8 @@ export default class CustomArrows extends Component {
       infinite: true,
       slidesToShow: 3,
       slidesToScroll: 1,
-      nextArrow: <SampleNextArrow />,
-      prevArrow: <SamplePrevArrow />
+      nextArrow: SampleNextArrow,
+      prevArrow: SamplePrevArrow
     };
     return (
       <div>

--- a/src/arrows.js
+++ b/src/arrows.js
@@ -32,7 +32,7 @@ export class PrevArrow extends React.Component {
     var prevArrow;
 
     if (this.props.prevArrow) {
-      prevArrow = React.cloneElement(this.props.prevArrow, { ...prevArrowProps, ...customProps });
+      prevArrow = React.createElement(this.props.prevArrow, { ...prevArrowProps, ...customProps });
     } else {
       prevArrow = <button key='0' type='button' {...prevArrowProps}> Previous</button>;
     }
@@ -70,7 +70,7 @@ export class NextArrow extends React.Component {
     var nextArrow;
 
     if (this.props.nextArrow) {
-      nextArrow = React.cloneElement(this.props.nextArrow, { ...nextArrowProps, ...customProps });
+      nextArrow = React.createElement(this.props.nextArrow, { ...nextArrowProps, ...customProps });
     } else {
       nextArrow = <button key='1' type='button' {...nextArrowProps}> Next</button>;
     }

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -16,9 +16,9 @@ var helpers = {
 
     if (!props.vertical) {
       var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
-      slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj)/props.slidesToShow;
+      slideWidth = (this.getWidth(ReactDOM.findDOMNode(this.list)) - centerPaddingAdj)/props.slidesToShow;
     } else {
-      slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
+      slideWidth = this.getWidth(ReactDOM.findDOMNode(this.list));
     }
 
     const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));
@@ -59,9 +59,9 @@ var helpers = {
 
     if (!props.vertical) {
       var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
-      slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj)/props.slidesToShow;
+      slideWidth = (this.getWidth(ReactDOM.findDOMNode(this.list)) - centerPaddingAdj)/props.slidesToShow;
     } else {
-      slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
+      slideWidth = this.getWidth(ReactDOM.findDOMNode(this.list));
     }
 
     const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));


### PR DESCRIPTION
Two changes:
* Switches the arrow elements from React Elements to React Components to better match recommended React paradigms
* Calculates the width of slide elements based on the parent `list` element rather than the entire slider element. This shouldn't break anything using the existing slick styling, but should allow for more flexible custom styling (such as including arrow elements within the width of the parent slider)