### PR TITLE
Variable Width Scrolling

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -218,6 +218,9 @@ var helpers = {
     }, this.props, this.state));
 
     if (this.props.infinite === false) {
+      if (targetLeft === currentLeft) {
+        targetSlide = currentSlide;
+      }
       targetLeft = currentLeft;
     }
 

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -129,6 +129,8 @@ export var getTrackLeft = function (spec) {
 
   if (spec.variableWidth === true) {
       var targetSlideIndex;
+      var lastSlide = ReactDOM.findDOMNode(spec.trackRef).children[spec.slideCount - 1];
+      var max = -(lastSlide.offsetLeft) + spec.listWidth - lastSlide.offsetWidth;
       if(spec.slideCount <= spec.slidesToShow || spec.infinite === false) {
           targetSlide = ReactDOM.findDOMNode(spec.trackRef).childNodes[spec.slideIndex];
       } else {
@@ -146,6 +148,9 @@ export var getTrackLeft = function (spec) {
           if (targetSlide) {
             targetLeft = targetSlide.offsetLeft * -1 + (spec.listWidth - targetSlide.offsetWidth) / 2;
           }
+      }
+      if (spec.infinite === false && targetLeft < max) {
+        targetLeft = max;
       }
   }
 


### PR DESCRIPTION
When scrolling on variable width with infinite false, stop at the end of the last slide. This is useful if you don't want to show empty space in the carousel.