### PR TITLE
Add error handling to prevent errors

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -104,7 +104,8 @@ var helpers = {
       var selector = '[data-index="' + this.state.currentSlide +'"]';
       if (this.list) {
         var slickList = ReactDOM.findDOMNode(this.list);
-        slickList.style.height = slickList.querySelector(selector).offsetHeight + 'px';
+        var elem = slickList.querySelector(selector) || {};
+        slickList.style.height = (elem.offsetHeight || 0) + 'px';
       }
     }
   },


### PR DESCRIPTION
I'm sorry I don't have a repro, but I have seen hundreds of our user stack traces in Sentry.  TypeError Cannot read property 'offsetHeight' of null in adaptHeight().  Maybe a rare timing scenario when the grid is initializing can cause this selector to return null.  

My change just defaults to empty object in this case so it doesn't hit a JavaScript error.

![sentryerror](https://user-images.githubusercontent.com/1902199/32293837-c9d429e8-bf1a-11e7-9ad9-fe228f323b40.png)
