### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ class SimpleSlider extends React.Component {
 |    Property    | Type |          Description          | Working |
 | -------------  | ---- |          -----------          | ------- |
 | accessibility  | bool | Enables tabbing and arrow key navigation | Yes |
-| className      | String |Additional class name for the inner slider div | Yes |
+| className      | string | Additional class name for the inner slider div | Yes |
 | adaptiveHeight | bool | Adjust the slide's height automatically | Yes |
 | arrows         | bool | Should we show Left and right nav arrows | Yes |
 | nextArrow      | React Element | Use this element for the next arrow button [Example](https://github.com/akiran/react-slick/blob/master/examples/CustomArrows.js) | Yes |
 | prevArrow      | React Element | Use this element for the prev arrow button [Example](https://github.com/akiran/react-slick/blob/master/examples/CustomArrows.js) | Yes |
 | autoplay       | bool | Should the scroller auto scroll? | Yes |
-| autoplaySpeed  |  int | delay between each auto scoll. in ms | Yes |
-| centerMode     | bool | Should we centre to a single item? | Yes |
+| autoplaySpeed  |  int | Delay between each auto scoll. in ms | Yes |
+| centerMode     | bool | Should we center to a single item? | Yes |
 | centerPadding  | | | |
 | cssEase        | | | |
 | customPaging   | func | Custom paging templates. [Example](https://github.com/akiran/react-slick/blob/master/examples/CustomPaging.js)| Yes |
@@ -90,10 +90,10 @@ class SimpleSlider extends React.Component {
 | easing         | string | | |
 | fade           | bool | Slides use fade for transition  | Yes |
 | focusOnSelect  | bool | Go to slide on click | Yes |
-| infinite       | bool | should the gallery wrap around its contents | Yes |
-| initialSlide   | int | which item should be the first to be displayed | Yes |
+| infinite       | bool | Should the gallery wrap around its contents | Yes |
+| initialSlide   | int | Which item should be the first to be displayed | Yes |
 | lazyLoad       | bool | Loads images or renders components on demands | Yes |
-| pauseOnHover   | bool | prevents autoplay while hovering | Yes |
+| pauseOnHover   | bool | Prevents autoplay while hovering | Yes |
 | responsive     | array | Array of objects in the form of `{ breakpoint: int, settings: { ... } }` The breakpoint _int_ is the `maxWidth` so the settings will be applied when resolution is below this value. Breakpoints in the array should be ordered from smallest to greatest. Use 'unslick' in place of the settings object to disable rendering the carousel at that breakpoint. Example: `[ { breakpoint: 768, settings: { slidesToShow: 3 } }, { breakpoint: 1024, settings: { slidesToShow: 5 } }, { breakpoint: 100000, settings: 'unslick' } ]`| Yes |
 | rtl            | bool | Reverses the slide order | Yes |
 | slide         | string |||
@@ -107,9 +107,9 @@ class SimpleSlider extends React.Component {
 | variableWidth | bool |||
 | useCSS | bool | Enable/Disable CSS Transitions | Yes |
 | vertical | bool | Vertical slide mode | Yes |
-| afterChange | function | callback function called after the current index changes. The new index is accessible in the first parameter of the callback function. | Yes |
-| beforeChange | function | callback function called before the current index changes. The old and the new indexes are accessible in the first and the second parameters of the callback function respectively. | Yes |
-| slickGoTo | int | go to the specified slide number | |
+| afterChange | function | Callback function called after the current index changes. The new index is accessible in the first parameter of the callback function. | Yes |
+| beforeChange | function | Callback function called before the current index changes. The old and the new indexes are accessible in the first and the second parameters of the callback function respectively. | Yes |
+| slickGoTo | int | Go to the specified slide number | |
 
 
 ### Methods


### PR DESCRIPTION
Putting uppercases at the beginning of sentences + fix 'centre' -> 'center'