### PR TITLE
Add option to indent slider Netflix-like on left and right.

### DIFF
--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -1,32 +1,32 @@
 'use strict';
 
 import React from 'react';
-import Slider from '../src/slider';
-
-import SimpleSlider from '../examples/SimpleSlider'
-import SlideChangeHooks from '../examples/SlideChangeHooks'
-import MultipleItems from '../examples/MultipleItems'
-import Responsive from '../examples/Responsive'
-import UnevenSetsInfinite from '../examples/UnevenSetsInfinite'
-import UnevenSetsFinite from '../examples/UnevenSetsFinite'
-import CenterMode from '../examples/CenterMode'
-import FocusOnSelect from '../examples/FocusOnSelect'
-import AutoPlay from '../examples/AutoPlay'
-import PauseOnHover from '../examples/PauseOnHover'
-import Rtl from '../examples/Rtl'
-import VariableWidth from '../examples/VariableWidth'
 import AdaptiveHeight from '../examples/AdaptiveHeight'
-import LazyLoad from '../examples/LazyLoad'
-import Fade from '../examples/Fade'
-import SlickGoTo from '../examples/SlickGoTo'
+import AutoPlay from '../examples/AutoPlay'
+import CenterMode from '../examples/CenterMode'
 import CustomArrows from '../examples/CustomArrows'
-import PreviousNextMethods from '../examples/PreviousNextMethods'
-import DynamicSlides  from '../examples/DynamicSlides'
-import VerticalMode  from '../examples/VerticalMode'
-import SwipeToSlide from '../examples/SwipeToSlide'
-import VerticalSwipeToSlide from '../examples/VerticalSwipeToSlide'
 import CustomPaging from '../examples/CustomPaging'
 import CustomSlides from '../examples/CustomSlides'
+import DynamicSlides from '../examples/DynamicSlides'
+import Fade from '../examples/Fade'
+import FocusOnSelect from '../examples/FocusOnSelect'
+import IndentedSlider from '../examples/IndentedSlider';
+import LazyLoad from '../examples/LazyLoad'
+import MultipleItems from '../examples/MultipleItems'
+import PauseOnHover from '../examples/PauseOnHover'
+import PreviousNextMethods from '../examples/PreviousNextMethods'
+import Responsive from '../examples/Responsive'
+import Rtl from '../examples/Rtl'
+
+import SimpleSlider from '../examples/SimpleSlider'
+import SlickGoTo from '../examples/SlickGoTo'
+import SlideChangeHooks from '../examples/SlideChangeHooks'
+import SwipeToSlide from '../examples/SwipeToSlide'
+import UnevenSetsFinite from '../examples/UnevenSetsFinite'
+import UnevenSetsInfinite from '../examples/UnevenSetsInfinite'
+import VariableWidth from '../examples/VariableWidth'
+import VerticalMode from '../examples/VerticalMode'
+import VerticalSwipeToSlide from '../examples/VerticalSwipeToSlide'
 
 export default class App extends React.Component {
   render() {
@@ -56,6 +56,7 @@ export default class App extends React.Component {
         <VerticalMode />
         <SwipeToSlide />
         <VerticalSwipeToSlide />
+        <IndentedSlider />
       </div>
     );
   }

--- a/examples/IndentedSlider.js
+++ b/examples/IndentedSlider.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react'
+import Slider from '../src/slider'
+
+export default class IndentedSlider extends Component {
+  render() {
+    const settings = {
+      dots: true,
+      infinite: true,
+      speed: 500,
+      slidesToShow: 3,
+      slidesToScroll: 3,
+      indent: 50
+    };
+    return (
+      <div>
+        <h2> Indented Slider</h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -45,7 +45,8 @@ var defaultProps = {
     swipeEvent: null,
     // nextArrow, prevArrow are react componets
     nextArrow: null,
-    prevArrow: null
+    prevArrow: null,
+    indent: 0
 };
 
 module.exports = defaultProps;

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -147,7 +147,8 @@ export var InnerSlider = createReactClass({
       slidesToScroll: this.props.slidesToScroll,
       slideCount: this.state.slideCount,
       trackStyle: this.state.trackStyle,
-      variableWidth: this.props.variableWidth
+      variableWidth: this.props.variableWidth,
+      indent: this.props.indent
     };
 
     var dots;

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -1,9 +1,9 @@
 'use strict';
 
+import assign from 'object-assign';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {getTrackCSS, getTrackLeft, getTrackAnimateCSS} from './trackHelper';
-import assign from 'object-assign';
+import { getTrackAnimateCSS, getTrackCSS, getTrackLeft } from './trackHelper';
 
 var helpers = {
   initialize: function (props) {
@@ -14,11 +14,14 @@ var helpers = {
     var trackWidth = this.getWidth(ReactDOM.findDOMNode(this.track));
     var slideWidth;
 
+    var indent = props.infinite ? props.indent * 2 : 0;
+    var indentPerSlide = indent / props.slidesToShow;
+
     if (!props.vertical) {
       var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
-      slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj)/props.slidesToShow;
+      slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj) / props.slidesToShow - indentPerSlide;
     } else {
-      slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
+      slideWidth = this.getWidth(ReactDOM.findDOMNode(this)) - indent;
     }
 
     const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));
@@ -41,9 +44,9 @@ var helpers = {
         trackRef: this.track
       }, props, this.state));
       // getCSS function needs previously set state
-      var trackStyle = getTrackCSS(assign({left: targetLeft}, props, this.state));
+      var trackStyle = getTrackCSS(assign({ left: targetLeft }, props, this.state));
 
-      this.setState({trackStyle: trackStyle});
+      this.setState({ trackStyle: trackStyle });
 
       this.autoPlay(); // once we're set up, trigger the initial autoplay.
     });
@@ -57,18 +60,21 @@ var helpers = {
     var trackWidth = this.getWidth(ReactDOM.findDOMNode(this.track));
     var slideWidth;
 
+    var indent = props.infinite ? props.indent * 2 : 0;
+    var indentPerSlide = indent / props.slidesToShow;
+
     if (!props.vertical) {
       var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
-      slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj)/props.slidesToShow;
+      slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj) / props.slidesToShow - indentPerSlide;
     } else {
-      slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
+      slideWidth = this.getWidth(ReactDOM.findDOMNode(this)) - indent;
     }
 
     const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));
     const listHeight = slideHeight * props.slidesToShow;
 
     // pause slider if autoplay is set to false
-    if(!props.autoplay) {
+    if (!props.autoplay) {
       this.pause();
     } else {
       this.autoPlay();
@@ -88,9 +94,9 @@ var helpers = {
         trackRef: this.track
       }, props, this.state));
       // getCSS function needs previously set state
-      var trackStyle = getTrackCSS(assign({left: targetLeft}, props, this.state));
+      var trackStyle = getTrackCSS(assign({ left: targetLeft }, props, this.state));
 
-      this.setState({trackStyle: trackStyle});
+      this.setState({ trackStyle: trackStyle });
     });
   },
   getWidth: function getWidth(elem) {
@@ -101,14 +107,14 @@ var helpers = {
   },
   adaptHeight: function () {
     if (this.props.adaptiveHeight) {
-      var selector = '[data-index="' + this.state.currentSlide +'"]';
+      var selector = '[data-index="' + this.state.currentSlide + '"]';
       if (this.list) {
         var slickList = ReactDOM.findDOMNode(this.list);
         slickList.style.height = slickList.querySelector(selector).offsetHeight + 'px';
       }
     }
   },
-  canGoNext: function (opts){
+  canGoNext: function (opts) {
     var canGo = true;
     if (!opts.infinite) {
       if (opts.centerMode) {
@@ -141,7 +147,7 @@ var helpers = {
       currentSlide = this.state.currentSlide;
 
       // Don't change slide if it's not infite and current slide is the first or last slide.
-      if(this.props.infinite === false &&
+      if (this.props.infinite === false &&
         (index < 0 || index >= this.state.slideCount)) {
         return;
       }
@@ -188,7 +194,7 @@ var helpers = {
 
     targetSlide = index;
     if (targetSlide < 0) {
-      if(this.props.infinite === false) {
+      if (this.props.infinite === false) {
         currentSlide = 0;
       } else if (this.state.slideCount % this.props.slidesToScroll !== 0) {
         currentSlide = this.state.slideCount - (this.state.slideCount % this.props.slidesToScroll);
@@ -196,7 +202,7 @@ var helpers = {
         currentSlide = this.state.slideCount + targetSlide;
       }
     } else if (targetSlide >= this.state.slideCount) {
-      if(this.props.infinite === false) {
+      if (this.props.infinite === false) {
         currentSlide = this.state.slideCount - this.props.slidesToShow;
       } else if (this.state.slideCount % this.props.slidesToScroll !== 0) {
         currentSlide = 0;
@@ -228,7 +234,7 @@ var helpers = {
     if (this.props.lazyLoad) {
       var loaded = true;
       var slidesToLoad = [];
-      for (var i = targetSlide; i < targetSlide + this.props.slidesToShow; i++ ) {
+      for (var i = targetSlide; i < targetSlide + this.props.slidesToShow; i++) {
         loaded = loaded && (this.state.lazyLoadedList.indexOf(i) >= 0);
         if (!loaded) {
           slidesToLoad.push(i);
@@ -250,7 +256,7 @@ var helpers = {
 
       this.setState({
         currentSlide: currentSlide,
-        trackStyle: getTrackCSS(assign({left: currentLeft}, this.props, this.state))
+        trackStyle: getTrackCSS(assign({ left: currentLeft }, this.props, this.state))
       }, function () {
         if (this.props.afterChange) {
           this.props.afterChange(currentSlide);
@@ -262,7 +268,7 @@ var helpers = {
       var nextStateChanges = {
         animating: false,
         currentSlide: currentSlide,
-        trackStyle: getTrackCSS(assign({left: currentLeft}, this.props, this.state)),
+        trackStyle: getTrackCSS(assign({ left: currentLeft }, this.props, this.state)),
         swipeLeft: null
       };
 
@@ -277,7 +283,7 @@ var helpers = {
       this.setState({
         animating: true,
         currentSlide: currentSlide,
-        trackStyle: getTrackAnimateCSS(assign({left: targetLeft}, this.props, this.state))
+        trackStyle: getTrackAnimateCSS(assign({ left: targetLeft }, this.props, this.state))
       }, function () {
         this.animationEndCallback = setTimeout(callback, this.props.speed);
       });
@@ -295,13 +301,13 @@ var helpers = {
 
     swipeAngle = Math.round(r * 180 / Math.PI);
     if (swipeAngle < 0) {
-        swipeAngle = 360 - Math.abs(swipeAngle);
+      swipeAngle = 360 - Math.abs(swipeAngle);
     }
     if ((swipeAngle <= 45) && (swipeAngle >= 0) || (swipeAngle <= 360) && (swipeAngle >= 315)) {
-        return (this.props.rtl === false ? 'left' : 'right');
+      return (this.props.rtl === false ? 'left' : 'right');
     }
     if ((swipeAngle >= 135) && (swipeAngle <= 225)) {
-        return (this.props.rtl === false ? 'right' : 'left');
+      return (this.props.rtl === false ? 'right' : 'left');
     }
     if (this.props.verticalSwiping === true) {
       if ((swipeAngle >= 35) && (swipeAngle <= 135)) {
@@ -313,7 +319,7 @@ var helpers = {
 
     return 'vertical';
   },
-  play: function(){
+  play: function () {
     var nextIndex;
 
     if (!this.state.mounted) {
@@ -323,7 +329,7 @@ var helpers = {
     if (this.props.rtl) {
       nextIndex = this.state.currentSlide - this.props.slidesToScroll;
     } else {
-      if (this.canGoNext(Object.assign({}, this.props,this.state))) {
+      if (this.canGoNext(Object.assign({}, this.props, this.state))) {
         nextIndex = this.state.currentSlide + this.props.slidesToScroll;
       } else {
         return false;

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -14,14 +14,14 @@ var helpers = {
     var trackWidth = this.getWidth(ReactDOM.findDOMNode(this.track));
     var slideWidth;
 
-    var indent = props.infinite ? props.indent * 2 : 0;
-    var indentPerSlide = indent / props.slidesToShow;
+    const indent = props.infinite ? props.indent * 2 : 0;
+    const indentPerSlide = indent / props.slidesToShow;
 
     if (!props.vertical) {
       var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
       slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj) / props.slidesToShow - indentPerSlide;
     } else {
-      slideWidth = this.getWidth(ReactDOM.findDOMNode(this)) - indent;
+      slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
     }
 
     const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));
@@ -60,14 +60,14 @@ var helpers = {
     var trackWidth = this.getWidth(ReactDOM.findDOMNode(this.track));
     var slideWidth;
 
-    var indent = props.infinite ? props.indent * 2 : 0;
-    var indentPerSlide = indent / props.slidesToShow;
+    const indent = props.infinite ? props.indent * 2 : 0;
+    const indentPerSlide = indent / props.slidesToShow;
 
     if (!props.vertical) {
       var centerPaddingAdj = props.centerMode && (parseInt(props.centerPadding) * 2);
       slideWidth = (this.getWidth(ReactDOM.findDOMNode(this)) - centerPaddingAdj) / props.slidesToShow - indentPerSlide;
     } else {
-      slideWidth = this.getWidth(ReactDOM.findDOMNode(this)) - indent;
+      slideWidth = this.getWidth(ReactDOM.findDOMNode(this));
     }
 
     const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -30,15 +30,19 @@ export var getTrackCSS = function (spec) {
     trackHeight = trackChildren * spec.slideHeight;
   }
 
-  var left = spec.indent && !spec.variableWidth ? (spec.left + spec.indent - spec.slideWidth) : spec.left;
+  const indentLeft = spec.left + spec.indent - spec.slideWidth;
+  let left = spec.infinite && spec.indent && !spec.variableWidth && !spec.vertical ? indentLeft : spec.left;
+  if (spec.vertical && spec.indent) {
+    left = left - spec.slideHeight;
+  }
 
   var style = {
     opacity: 1,
-    WebkitTransform: !spec.vertical ? 'translate3d(' + left + 'px, 0px, 0px)' : 'translate3d(0px, ' + (spec.left - spec.slideHeight) + 'px, 0px)',
-    transform: !spec.vertical ? 'translate3d(' + left + 'px, 0px, 0px)' : 'translate3d(0px, ' + (spec.left - spec.slideHeight) + 'px, 0px)',
+    WebkitTransform: !spec.vertical ? 'translate3d(' + left + 'px, 0px, 0px)' : 'translate3d(0px, ' + left + 'px, 0px)',
+    transform: !spec.vertical ? 'translate3d(' + left + 'px, 0px, 0px)' : 'translate3d(0px, ' + left + 'px, 0px)',
     transition: '',
     WebkitTransition: '',
-    msTransform: !spec.vertical ? 'translateX(' + left + 'px)' : 'translateY(' + (spec.left - spec.slideHeight) + 'px)',
+    msTransform: !spec.vertical ? 'translateX(' + left + 'px)' : 'translateY(' + left + 'px)',
   };
 
   if (trackWidth) {

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -1,6 +1,6 @@
 'use strict';
-import ReactDOM from 'react-dom';
 import assign from 'object-assign';
+import ReactDOM from 'react-dom';
 
 var checkSpecKeys = function (spec, keysArray) {
   return keysArray.reduce((value, key) => {
@@ -8,34 +8,37 @@ var checkSpecKeys = function (spec, keysArray) {
   }, true) ? null : console.error('Keys Missing', spec);
 };
 
-export var getTrackCSS = function(spec) {
+export var getTrackCSS = function (spec) {
   checkSpecKeys(spec, [
-    'left', 'variableWidth', 'slideCount', 'slidesToShow', 'slideWidth'
+    'left', 'variableWidth', 'slideCount', 'slidesToShow', 'slideWidth', 'spaceLeft'
   ]);
 
   var trackWidth, trackHeight;
 
   const trackChildren = (spec.slideCount + 2 * spec.slidesToShow);
+  const indent = spec.indent ? spec.slideWidth * 2 : 0;
 
   if (!spec.vertical) {
     if (spec.variableWidth) {
-      trackWidth = (spec.slideCount + 2*spec.slidesToShow) * spec.slideWidth;
+      trackWidth = (spec.slideCount + 2 * spec.slidesToShow) * spec.slideWidth;
     } else if (spec.centerMode) {
-      trackWidth = (spec.slideCount + 2*(spec.slidesToShow + 1)) * spec.slideWidth;
+      trackWidth = (spec.slideCount + 2 * (spec.slidesToShow + 1)) * spec.slideWidth;
     } else {
-      trackWidth = (spec.slideCount + 2*spec.slidesToShow) * spec.slideWidth;
+      trackWidth = (spec.slideCount + 2 * spec.slidesToShow) * spec.slideWidth + indent;
     }
   } else {
     trackHeight = trackChildren * spec.slideHeight;
   }
 
+  var left = spec.indent && !spec.variableWidth ? (spec.left + spec.indent - spec.slideWidth) : spec.left;
+
   var style = {
     opacity: 1,
-    WebkitTransform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
-    transform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
+    WebkitTransform: !spec.vertical ? 'translate3d(' + left + 'px, 0px, 0px)' : 'translate3d(0px, ' + (spec.left - spec.slideHeight) + 'px, 0px)',
+    transform: !spec.vertical ? 'translate3d(' + left + 'px, 0px, 0px)' : 'translate3d(0px, ' + (spec.left - spec.slideHeight) + 'px, 0px)',
     transition: '',
     WebkitTransition: '',
-    msTransform: !spec.vertical ? 'translateX(' + spec.left + 'px)' : 'translateY(' + spec.left + 'px)',
+    msTransform: !spec.vertical ? 'translateX(' + left + 'px)' : 'translateY(' + (spec.left - spec.slideHeight) + 'px)',
   };
 
   if (trackWidth) {
@@ -71,10 +74,10 @@ export var getTrackAnimateCSS = function (spec) {
 };
 
 export var getTrackLeft = function (spec) {
-
   checkSpecKeys(spec, [
-   'slideIndex', 'trackRef', 'infinite', 'centerMode', 'slideCount', 'slidesToShow',
-   'slidesToScroll', 'slideWidth', 'listWidth', 'variableWidth', 'slideHeight']);
+    'slideIndex', 'trackRef', 'infinite', 'centerMode', 'slideCount', 'slidesToShow',
+    'slidesToScroll', 'slideWidth', 'listWidth', 'variableWidth', 'slideHeight'
+  ]);
 
   var slideOffset = 0;
   var targetLeft;
@@ -92,29 +95,28 @@ export var getTrackLeft = function (spec) {
     }
     if (spec.slideCount % spec.slidesToScroll !== 0) {
       if (spec.slideIndex + spec.slidesToScroll > spec.slideCount && spec.slideCount > spec.slidesToShow) {
-          if(spec.slideIndex > spec.slideCount) {
-            slideOffset = ((spec.slidesToShow - (spec.slideIndex - spec.slideCount)) * spec.slideWidth) * -1;
-            verticalOffset = ((spec.slidesToShow - (spec.slideIndex - spec.slideCount)) * spec.slideHeight) * -1;
-          } else {
-            slideOffset = ((spec.slideCount % spec.slidesToScroll) * spec.slideWidth) * -1;
-            verticalOffset = ((spec.slideCount % spec.slidesToScroll) * spec.slideHeight) * -1;
-          }
+        if (spec.slideIndex > spec.slideCount) {
+          slideOffset = ((spec.slidesToShow - (spec.slideIndex - spec.slideCount)) * spec.slideWidth) * -1;
+          verticalOffset = ((spec.slidesToShow - (spec.slideIndex - spec.slideCount)) * spec.slideHeight) * -1;
+        } else {
+          slideOffset = ((spec.slideCount % spec.slidesToScroll) * spec.slideWidth) * -1;
+          verticalOffset = ((spec.slideCount % spec.slidesToScroll) * spec.slideHeight) * -1;
+        }
       }
     }
   } else {
 
     if (spec.slideCount % spec.slidesToScroll !== 0) {
       if (spec.slideIndex + spec.slidesToScroll > spec.slideCount && spec.slideCount > spec.slidesToShow) {
-          var slidesToOffset = spec.slidesToShow - (spec.slideCount % spec.slidesToScroll);
-          slideOffset = slidesToOffset * spec.slideWidth;
+        var slidesToOffset = spec.slidesToShow - (spec.slideCount % spec.slidesToScroll);
+        slideOffset = slidesToOffset * spec.slideWidth;
       }
     }
   }
 
 
-
   if (spec.centerMode) {
-    if(spec.infinite) {
+    if (spec.infinite) {
       slideOffset += spec.slideWidth * Math.floor(spec.slidesToShow / 2);
     } else {
       slideOffset = spec.slideWidth * Math.floor(spec.slidesToShow / 2);
@@ -128,25 +130,25 @@ export var getTrackLeft = function (spec) {
   }
 
   if (spec.variableWidth === true) {
-      var targetSlideIndex;
-      if(spec.slideCount <= spec.slidesToShow || spec.infinite === false) {
-          targetSlide = ReactDOM.findDOMNode(spec.trackRef).childNodes[spec.slideIndex];
+    var targetSlideIndex;
+    if (spec.slideCount <= spec.slidesToShow || spec.infinite === false) {
+      targetSlide = ReactDOM.findDOMNode(spec.trackRef).childNodes[spec.slideIndex];
+    } else {
+      targetSlideIndex = (spec.slideIndex + spec.slidesToShow);
+      targetSlide = ReactDOM.findDOMNode(spec.trackRef).childNodes[targetSlideIndex];
+    }
+    targetLeft = targetSlide ? targetSlide.offsetLeft * -1 : 0;
+    if (spec.centerMode === true) {
+      if (spec.infinite === false) {
+        targetSlide = ReactDOM.findDOMNode(spec.trackRef).children[spec.slideIndex];
       } else {
-          targetSlideIndex = (spec.slideIndex + spec.slidesToShow);
-          targetSlide = ReactDOM.findDOMNode(spec.trackRef).childNodes[targetSlideIndex];
+        targetSlide = ReactDOM.findDOMNode(spec.trackRef).children[(spec.slideIndex + spec.slidesToShow + 1)];
       }
-      targetLeft = targetSlide ? targetSlide.offsetLeft * -1 : 0;
-      if (spec.centerMode === true) {
-          if(spec.infinite === false) {
-              targetSlide = ReactDOM.findDOMNode(spec.trackRef).children[spec.slideIndex];
-          } else {
-              targetSlide = ReactDOM.findDOMNode(spec.trackRef).children[(spec.slideIndex + spec.slidesToShow + 1)];
-          }
 
-          if (targetSlide) {
-            targetLeft = targetSlide.offsetLeft * -1 + (spec.listWidth - targetSlide.offsetWidth) / 2;
-          }
+      if (targetSlide) {
+        targetLeft = targetSlide.offsetLeft * -1 + (spec.listWidth - targetSlide.offsetWidth) / 2;
       }
+    }
   }
 
   return targetLeft;

--- a/src/track.js
+++ b/src/track.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import React from 'react';
-import assign from 'object-assign';
 import classnames from 'classnames';
+import assign from 'object-assign';
+import React from 'react';
 
 var getSlideClasses = (spec) => {
   var slickActive, slickCenter, slickCloned;
@@ -50,8 +50,8 @@ var getSlideStyle = function (spec) {
 };
 
 var getKey = (child, fallbackKey) => {
-    // key could be a zero
-    return (child.key === null || child.key === undefined) ? fallbackKey : child.key;
+  // key could be a zero
+  return (child.key === null || child.key === undefined) ? fallbackKey : child.key;
 };
 
 var renderSlides = function (spec) {
@@ -60,7 +60,6 @@ var renderSlides = function (spec) {
   var preCloneSlides = [];
   var postCloneSlides = [];
   var count = React.Children.count(spec.children);
-
 
   React.Children.forEach(spec.children, (elem, index) => {
     let child;
@@ -76,10 +75,10 @@ var renderSlides = function (spec) {
     } else {
       child = (<div></div>);
     }
-    var childStyle = getSlideStyle(assign({}, spec, {index: index}));
+    var childStyle = getSlideStyle(assign({}, spec, { index: index }));
     const slideClass = child.props.className || ''
 
-    const onClick = function(e) {
+    const onClick = function (e) {
       child.props && child.props.onClick && child.props.onClick(e)
       if (spec.focusOnSelect) {
         spec.focusOnSelect(childOnClickOptions)
@@ -89,33 +88,58 @@ var renderSlides = function (spec) {
     slides.push(React.cloneElement(child, {
       key: 'original' + getKey(child, index),
       'data-index': index,
-      className: classnames(getSlideClasses(assign({index: index}, spec)), slideClass),
+      className: classnames(getSlideClasses(assign({ index: index }, spec)), slideClass),
       tabIndex: '-1',
-      style: assign({outline: 'none'}, child.props.style || {}, childStyle),
+      style: assign({ outline: 'none' }, child.props.style || {}, childStyle),
       onClick
     }));
 
     // variableWidth doesn't wrap properly.
     if (spec.infinite && spec.fade === false) {
       var infiniteCount = spec.variableWidth ? spec.slidesToShow + 1 : spec.slidesToShow;
+      const indentSlide = Math.ceil(spec.indent / childStyle.width);
+      const addPreIndent = spec.indent && count === spec.slidesToShow && index === spec.slidesToShow - 1;
+      const addPostIndent = spec.indent && count === spec.slidesToShow && index === 0;
 
-      if (index >= (count - infiniteCount)) {
+      if (index >= (count - infiniteCount - indentSlide)) {
         key = -(count - index);
         preCloneSlides.push(React.cloneElement(child, {
           key: 'precloned' + getKey(child, key),
           'data-index': key,
-          className: classnames(getSlideClasses(assign({index: key}, spec)), slideClass),
+          className: classnames(getSlideClasses(assign({ index: key }, spec)), slideClass),
           style: assign({}, child.props.style || {}, childStyle),
           onClick
         }));
       }
 
-      if (index < infiniteCount) {
+      if (addPreIndent) {
+        key = -(count + 1);
+        preCloneSlides.unshift(React.cloneElement(child, {
+          key: 'indent-precloned' + getKey(child, key),
+          'data-index': key,
+          className: classnames(getSlideClasses(assign({ index: key }, spec)), slideClass),
+          style: assign({}, child.props.style || {}, childStyle),
+          onClick
+        }));
+      }
+
+      if ((index - indentSlide) < infiniteCount) {
         key = count + index;
-        postCloneSlides.push(React.cloneElement(child, {
+        postCloneSlides.splice(index, 0, (React.cloneElement(child, {
           key: 'postcloned' + getKey(child, key),
           'data-index': key,
-          className: classnames(getSlideClasses(assign({index: key}, spec)), slideClass),
+          className: classnames(getSlideClasses(assign({ index: key }, spec)), slideClass),
+          style: assign({}, child.props.style || {}, childStyle),
+          onClick
+        })));
+      }
+
+      if (addPostIndent) {
+        key = count * 2;
+        postCloneSlides.push(React.cloneElement(child, {
+          key: 'indent-postcloned' + getKey(child, key),
+          'data-index': key,
+          className: classnames(getSlideClasses(assign({ index: key }, spec)), slideClass),
           style: assign({}, child.props.style || {}, childStyle),
           onClick
         }));
@@ -135,9 +159,10 @@ var renderSlides = function (spec) {
 export class Track extends React.Component {
   render() {
     var slides = renderSlides.call(this, this.props);
+    console.info('render', 'slides', slides);
     return (
       <div className='slick-track' style={this.props.trackStyle}>
-        { slides }
+        {slides}
       </div>
     );
   }


### PR DESCRIPTION
In my company we needed a Netflix-like slider that show next and previous slides.

This pull request extends the react-slick slider to allow indentation on both left and right.

Indentation will not work in vertical and infinite=false mode.