### PR TITLE
Fix prev button in center mode

### DIFF
--- a/src/arrows.js
+++ b/src/arrows.js
@@ -13,7 +13,8 @@ export class PrevArrow extends React.Component {
     var prevClasses = {'slick-arrow': true, 'slick-prev': true};
     var prevHandler = this.clickHandler.bind(this, {message: 'previous'});
 
-    if (!this.props.infinite && (this.props.currentSlide === 0 || this.props.slideCount <= this.props.slidesToShow)) {
+    if (!this.props.infinite && (this.props.currentSlide === 0
+            || (this.props.slideCount <= this.props.slidesToShow && !this.props.centerMode))) {
       prevClasses['slick-disabled'] = true;
       prevHandler = null;
     }


### PR DESCRIPTION
Prev button should work even though slideCount <= slidesToShow when center mode is enabled