### PR TITLE
Fix bug on slickActive for items on last slide

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -21,7 +21,11 @@ var getSlideClasses = (spec) => {
       slickActive = true;
     }
   } else {
-    slickActive = (spec.currentSlide <= index) && (index < spec.currentSlide + spec.slidesToShow);
+    slickActive =
+      (spec.currentSlide <= index &&
+        index < spec.currentSlide + spec.slidesToShow) ||
+      index > spec.slideCount - spec.slidesToShow;
+
   }
   return classnames({
     'slick-slide': true,


### PR DESCRIPTION
Fix an issue with slickActive for items on last slide.
Same as https://github.com/akiran/react-slick/issues/764