### PR TITLE
Remove slick-carousel from peer and core dependancies and more to dev-dependancies in line with foundation styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm install slick-carousel
 @import "~slick-carousel/slick/slick-theme.css";
 ```
 
+But be aware slick-carousel has a peer-dependancy on jQuery which you, or your colleagues may not like to see in your console output, so you can always grab the CSS from there and convert it into any CSS in JS solution that you might be using. 
+
 or add cdn link in your html
 
 ```html

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "run-sequence": "^1.2.2",
     "sass-loader": "^6.0.3",
     "sinon": "^2.1.0",
+    "slick-carousel": "^1.8.1",
     "style-loader": "^0.16.1",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.16.1"
@@ -75,13 +76,11 @@
     "create-react-class": "^15.5.2",
     "enquire.js": "^2.1.6",
     "json2mq": "^0.2.0",
-    "object-assign": "^4.1.0",
-    "slick-carousel": "^1.8.1"
+    "object-assign": "^4.1.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.1 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0",
-    "slick-carousel": "^1.6.0 || ^1.8.0"
+    "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0"
   },
   "jest": {
     "setupFiles": [


### PR DESCRIPTION
First of all thanks for your work over the years, I have used slick-carousel in the past and since moving to React this is the first time I have need a carousel so this was my first port of call.

This is a small one to remove the unease from my colleagues when they see 'slick-carousel' requires a peer-dependancy of jQuery... They say things like:
'Mark, I mean really, are you trying to add jQuery into our shiny new project?' 

or someone more junior else will say:
'Hey, I've add jQuery as per the output from the console on npm install, the carousel needs it!'

and of course I would feel better not having to see peer-dependancies not met on purpose :-)

Anyways, any chance of getting this in? The docs actually already say you need to install slick-carousel anyway for the CSS and font, so I assume that you might have intended it to be link this anyway. The only place you use the styles is in conjunction with foundation which is listed only as a dev-dependancy so this way all is consistent :-)