### PR TITLE
Add options for server side rendering responsive sliders

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Props            | Type            | Default Value                   | Descripti
 `slidesToShow`   | `int`           | `1`                             | Yes                                                         | Yes
 `slidesToScroll` | `int`           | `1`                             |                                                             |
 `speed`          | `int`           | `500`                           |                                                             |
+`ssr`            | `bool`          | `false`                         | True if you SSR and use `responsive` prop (see below)       | Yes
+`ssrBreakpoint`  | `int`           | `null`                          | The breakpoint to use during SSR (see `responsive` below)   | Yes
 `swipe`          | `bool`          | `true`                          |                                                             |
 `swipeToSlide`   | `bool`          | `false`                         | Enable drag/swpie irrespective of `slidesToScroll`          | Yes
 `touchMove`      | `bool`          | `true`                          |                                                             |
@@ -122,6 +124,8 @@ Props            | Type            | Default Value                   | Descripti
 #### `responsive` property
 
 Array of objects in the form of `{ breakpoint: int, settings: { ... } }` The breakpoint _int_ is the `maxWidth` so the settings will be applied when resolution is below this value. Breakpoints in the array should be ordered from smallest to greatest. Use 'unslick' in place of the settings object to disable rendering the carousel at that breakpoint. Example: `[ { breakpoint: 768, settings: { slidesToShow: 3 } }, { breakpoint: 1024, settings: { slidesToShow: 5 } }, { breakpoint: 100000, settings: 'unslick' } ]`
+
+If you are using the responsive property and server side rendering be sure to set the `ssr` property to true. This will make sure when the client renders it uses the same settings as the server and doesn't change to your responsive settings until after mount. If you use server side client detection you can set `ssrBreakpoint` to have the server render with a specific breakpoints settings instead of the default.
 
 [customArrows]: https://github.com/akiran/react-slick/blob/master/examples/CustomArrows.js
 [customPaging]: https://github.com/akiran/react-slick/blob/master/examples/CustomPaging.js

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -30,6 +30,8 @@ var defaultProps = {
     slidesToShow: 1,
     slidesToScroll: 1,
     speed: 500,
+    ssr: false,
+    ssrBreakpoint: null,
     swipe: true,
     swipeToSlide: false,
     touchMove: true,

--- a/src/slider.js
+++ b/src/slider.js
@@ -12,10 +12,11 @@ export default class Slider extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      breakpoint: null
+      breakpoint: props.ssr ? props.ssrBreakpoint : null
     };
     this._responsiveMediaHandlers = [];
-    this.innerSliderRefHandler = this.innerSliderRefHandler.bind(this)
+    this.innerSliderRefHandler = this.innerSliderRefHandler.bind(this);
+    this.setupResponsiveHandlers = this.setupResponsiveHandlers.bind(this);
   }
   innerSliderRefHandler(ref) {
     this.innerSlider = ref;
@@ -24,7 +25,7 @@ export default class Slider extends React.Component {
     enquire.register(query, handler);
     this._responsiveMediaHandlers.push({query, handler});
   }
-  componentWillMount() {
+  setupResponsiveHandlers() {
     if (this.props.responsive) {
       var breakpoints = this.props.responsive.map(breakpt => breakpt.breakpoint);
       breakpoints.sort((x, y) => x - y);
@@ -47,6 +48,16 @@ export default class Slider extends React.Component {
       canUseDOM && this.media(query, () => {
         this.setState({breakpoint: null});
       });
+    }
+  }
+  componentWillMount() {
+    if (!this.props.ssr) {
+      this.setupResponsiveHandlers();
+    }
+  }
+  componentDidMount() {
+    if (this.props.ssr) {
+      this.setupResponsiveHandlers();
     }
   }
 


### PR DESCRIPTION
This is a PR to close issue #776. I have added an `ssr` prop that delays the setting up the responsive handlers until `componentDidMount`. This means the slider will render with default settings on the server. The client then renders also with the default settings so there is no checksum error and then is updated with the correct responsive settings and immediately re-rendered. I also added the ability to set which breakpoint settings the slider should use to render on the server side. This is useful if you have server side device detection and can guess which breakpoint your client will use. Also updated the docs to explain the new props.

The changes ended up being minimal and I have tested this within my project. Tried to write a test but found it very difficult since I needed to assert something was the case before `componentDidMount` and then also mock the enquire.js dependency. But happy to still write one with some guidance on how.