### PR TITLE
Add afterDots prop for an element after the props

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -46,7 +46,8 @@ var defaultProps = {
     swipeEvent: null,
     // nextArrow, prevArrow should react componets
     nextArrow: null,
-    prevArrow: null
+    prevArrow: null,
+    afterDots: null
 };
 
 export default defaultProps

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -183,6 +183,7 @@ export var InnerSlider = createReactClass({
     };
 
     var dots;
+    var afterDots;
 
     if (this.props.dots === true && this.state.slideCount >= this.props.slidesToShow) {
       var dotProps = {
@@ -197,6 +198,10 @@ export var InnerSlider = createReactClass({
       };
 
       dots = (<Dots {...dotProps} />);
+
+      if (this.props.afterDots) {
+        afterDots = this.props.afterDots;
+      }
     }
 
     var prevArrow, nextArrow;
@@ -270,6 +275,7 @@ export var InnerSlider = createReactClass({
         </div>
         {nextArrow}
         {dots}
+        {afterDots}
       </div>
     );
   }


### PR DESCRIPTION
The project I am working on requires an additional element after the dots have been render.

This would give a user a simple hook for rendering a custom element in the slider (eg. A zoom button, reset button, switch etc)