### PR TITLE
Add renderDots for custom rendering the dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Props            | Type            | Default Value                   | Descripti
 `customPaging`   | `func`          | `i => <button>{i + 1}</button>` | Custom paging templates. [Example](examples/CustomPaging.js)            | Yes
 `dots`           | `bool`          | `Default`                       |                                                             | Yes
 `dotsClass`      | `string`        | `'slick-dots'`                  | CSS class for dots                                          | Yes
+`renderDots`     | `func`          | `dots => <ul>{dots}</ul>`       | Custom dots templates. Works same as customPaging           | Yes
 `draggable`      | `bool`          | `true`                          | Enable scrollable via dragging on desktop                   | Yes
 `easing`         | `string`        | `'linear'`                      |                                                             |
 `fade`           | `bool`          | `Default`                       |                                                             | Yes

--- a/examples/__tests__/__snapshots__/SimpleSlider.test.js.snap
+++ b/examples/__tests__/__snapshots__/SimpleSlider.test.js.snap
@@ -47,7 +47,7 @@ exports[`Simple Slider Snapshots click on 3rd dot 1`] = `
                 </div>
             </div>
         </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button>
-        <ul class=\\"slick-dots\\" style=\\"display: block;\\">
+        <ul style=\\"display: block;\\" class=\\"slick-dots\\">
             <li class=\\"\\"><button>1</button></li>
             <li class=\\"\\"><button>2</button></li>
             <li class=\\"slick-active\\"><button>3</button></li>
@@ -106,7 +106,7 @@ exports[`Simple Slider Snapshots click on next button 1`] = `
                 </div>
             </div>
         </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button>
-        <ul class=\\"slick-dots\\" style=\\"display: block;\\">
+        <ul style=\\"display: block;\\" class=\\"slick-dots\\">
             <li class=\\"\\"><button>1</button></li>
             <li class=\\"slick-active\\"><button>2</button></li>
             <li class=\\"\\"><button>3</button></li>
@@ -165,7 +165,7 @@ exports[`Simple Slider Snapshots click on prev button 1`] = `
                 </div>
             </div>
         </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button>
-        <ul class=\\"slick-dots\\" style=\\"display: block;\\">
+        <ul style=\\"display: block;\\" class=\\"slick-dots\\">
             <li class=\\"\\"><button>1</button></li>
             <li class=\\"\\"><button>2</button></li>
             <li class=\\"\\"><button>3</button></li>
@@ -224,7 +224,7 @@ exports[`Simple Slider Snapshots slider initial state 1`] = `
                 </div>
             </div>
         </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button>
-        <ul class=\\"slick-dots\\" style=\\"display: block;\\">
+        <ul style=\\"display: block;\\" class=\\"slick-dots\\">
             <li class=\\"slick-active\\"><button>1</button></li>
             <li class=\\"\\"><button>2</button></li>
             <li class=\\"\\"><button>3</button></li>

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -46,7 +46,10 @@ var defaultProps = {
     swipeEvent: null,
     // nextArrow, prevArrow should react componets
     nextArrow: null,
-    prevArrow: null
+    prevArrow: null,
+    renderDots: function(dots) {
+        return <ul style={{display: 'block'}}>{dots}</ul>;
+    }
 };
 
 export default defaultProps

--- a/src/dots.js
+++ b/src/dots.js
@@ -59,10 +59,6 @@ export class Dots extends React.Component {
       );
     });
 
-    return (
-      <ul className={this.props.dotsClass} style={{display: 'block'}}>
-        {dots}
-      </ul>
-    );
+    return React.cloneElement(this.props.renderDots(dots), {className: this.props.dotsClass});
   }
 }

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -197,7 +197,8 @@ export var InnerSlider = createReactClass({
         clickHandler: this.changeSlide,
         children: this.props.children,
         customPaging: this.props.customPaging,
-        infinite: this.props.infinite
+        infinite: this.props.infinite,
+        renderDots: this.props.renderDots
       };
 
       dots = (<Dots {...dotProps} />);


### PR DESCRIPTION
Following on from [PR 1002](https://github.com/akiran/react-slick/pull/1002). This would add an attribute similar to that of appendDots in [slick](https://github.com/kenwheeler/slick).

It is done in the same style as `customPaging`, where users can provide a function for rendering the dots within a custom container. Meaning it should be both inline with the slick library, as well as inline with the coding standards of react-slick.

Thank-you for your consideration.