### PR TITLE
Add afterInit function after init and adaptHeight

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -42,7 +42,9 @@ var defaultProps = {
     beforeChange: null,
     edgeEvent: null,
     // init: function hook that gets called right before InnerSlider mounts
-    init: null, 
+    init: null,
+    // afterIniti: function hook after inner-slider calculates all it's sizes
+    afterInit: null, 
     swipeEvent: null,
     // nextArrow, prevArrow should react componets
     nextArrow: null,

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -71,6 +71,11 @@ export var InnerSlider = createReactClass({
     this.initialize(this.props);
     this.adaptHeight();
 
+    // Add hook after inner-slider calculates all it's sizes
+    if (this.props.afterInit) {
+      this.props.afterInit();
+    }
+
     // To support server-side rendering
     if (!window) {
       return


### PR DESCRIPTION
This PR address the issue found [here](https://github.com/akiran/react-slick/issues/429), regarding sudden flash prior to inner-slider loading.

We've have added this to Conde's internal fork and have seen great success!