### PR TITLE
adaptive height should calculate max height from all visible slides

### DIFF
--- a/examples/AdaptiveHeight.js
+++ b/examples/AdaptiveHeight.js
@@ -7,7 +7,7 @@ export default class AdaptiveHeight extends Component {
       className: '',
       dots: true,
       infinite: true,
-      slidesToShow: 1,
+      slidesToShow: 3,
       slidesToScroll: 1,
       adaptiveHeight: true
     };

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -108,11 +108,16 @@ var helpers = {
   },
   adaptHeight: function () {
     if (this.props.adaptiveHeight) {
-      var selector = '[data-index="' + this.state.currentSlide +'"]';
       if (this.list) {
         var slickList = ReactDOM.findDOMNode(this.list);
-        var elem = slickList.querySelector(selector) || {};
-        slickList.style.height = (elem.offsetHeight || 0) + 'px';
+        var maxHeight = 0
+        for (let i = 0; i < this.props.slidesToShow; i++) {
+          var slideIndex = this.state.currentSlide + i
+          var selector = '[data-index="' + slideIndex +'"]';
+          var elem = slickList.querySelector(selector) || {};
+          maxHeight = elem.offsetHeight || 0 > maxHeight ? elem.offsetHeight : maxHeight
+        }
+        slickList.style.height = maxHeight + 'px';
       }
     }
   },


### PR DESCRIPTION
Currently, `adaptiveHeight` only sets the height based on the current slide.  However, it should actually be the max height of all visible slides. 

I've updated the `AdaptiveHeight` example to show 3 slides to show this in action.