### PR TITLE
Fix/usage within dir rtl elements

### DIFF
--- a/docs/demosRTL.jsx
+++ b/docs/demosRTL.jsx
@@ -1,0 +1,22 @@
+'use strict';
+
+import React from 'react';
+import Slider from '../src/slider';
+
+import SimpleSlider from '../examples/SimpleSliderRTL'
+import MultipleItems from '../examples/MultipleItemsRTL'
+import Responsive from '../examples/ResponsiveRTL'
+import AdaptiveHeight from '../examples/AdaptiveHeightRTL'
+
+export default class App extends React.Component {
+  render() {
+    return (
+      <div dir='rtl' className='content'>
+        <SimpleSlider />
+        <MultipleItems />
+        <Responsive />
+        <AdaptiveHeight />
+      </div>
+    );
+  }
+}

--- a/docs/demosRTL.jsx
+++ b/docs/demosRTL.jsx
@@ -3,20 +3,50 @@
 import React from 'react';
 import Slider from '../src/slider';
 
-import SimpleSlider from '../examples/SimpleSliderRTL'
-import MultipleItems from '../examples/MultipleItemsRTL'
-import Responsive from '../examples/ResponsiveRTL'
-import AdaptiveHeight from '../examples/AdaptiveHeightRTL'
+import SimpleSliderRTL from '../examples/SimpleSliderRTL'
+import MultipleItemsRTL from '../examples/MultipleItemsRTL'
+import ResponsiveRTL from '../examples/ResponsiveRTL'
+import AdaptiveHeightRTL from '../examples/AdaptiveHeightRTL'
+import SimpleSlider from '../examples/SimpleSlider'
+import MultipleItems from '../examples/MultipleItems'
 
 export default class App extends React.Component {
   render() {
     return (
+    <div>
+
+
       <div dir='rtl' className='content'>
+        <div className='title-bar primary'>
+          <span className='title'>React Slick RTL - html attribute</span>
+        </div>
+        <SimpleSliderRTL />
+        <MultipleItemsRTL />
+        <ResponsiveRTL />
+        <AdaptiveHeightRTL />
+        {
+        // The following three are to demonstrate the default scroller behaviour
+        // inside rtl-pages.
+        }
         <SimpleSlider />
         <MultipleItems />
-        <Responsive />
-        <AdaptiveHeight />
       </div>
+      <div style={{ direction: 'rtl' }} className='content'>
+        <div className='title-bar primary'>
+          <span className='title'>React Slick RTL - inline style</span>
+        </div>
+        <SimpleSliderRTL />
+        <MultipleItemsRTL />
+        <ResponsiveRTL />
+        <AdaptiveHeightRTL />
+        {
+        // The following three are to demonstrate the default scroller behaviour
+        // inside rtl-pages.
+        }
+        <SimpleSlider />
+        <MultipleItems />
+      </div>
+    </div>
     );
   }
 }

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -16,14 +16,7 @@ export default class Docs extends React.Component {
             <Demos />
           </div>
         </div>
-        <div className='title-bar primary'>
-            <span className='title'>React Slick RTL</span>
-        </div>
-        <div className=''>
-          <div className=''>
-            <DemosRTL />
-          </div>
-        </div>
+        <DemosRTL />
       </div>
     );
   }

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Demos from './demos'
+import DemosRTL from './demosRTL'
 
 export default class Docs extends React.Component {
   render() {
@@ -13,6 +14,14 @@ export default class Docs extends React.Component {
         <div className=''>
           <div className=''>
             <Demos />
+          </div>
+        </div>
+        <div className='title-bar primary'>
+            <span className='title'>React Slick RTL</span>
+        </div>
+        <div className=''>
+          <div className=''>
+            <DemosRTL />
           </div>
         </div>
       </div>

--- a/examples/AdaptiveHeightRTL.js
+++ b/examples/AdaptiveHeightRTL.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react'
+import Slider from '../src/slider'
+
+export default class AdaptiveHeight extends Component {
+  render() {
+    var settings = {
+      className: '',
+      rtl: true,
+      dots: true,
+      infinite: true,
+      slidesToShow: 1,
+      slidesToScroll: 1,
+      adaptiveHeight: true
+    };
+    return (
+      <div dir="rtl">
+        <h2>Adaptive height</h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div>
+            <h3>2</h3>
+            <p>Hello</p>
+          </div>
+          <div>
+            <h3>3</h3>
+            <p>See ....</p>
+            <p>Height is adaptive</p>
+          </div>
+          <div>
+            <h3>4</h3>
+          </div>
+          <div>
+            <h3>5</h3>
+          </div>
+          <div>
+            <h3>6</h3>
+          </div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/examples/AdaptiveHeightRTL.js
+++ b/examples/AdaptiveHeightRTL.js
@@ -14,7 +14,7 @@ export default class AdaptiveHeight extends Component {
     };
     return (
       <div dir="rtl">
-        <h2>Adaptive height</h2>
+        <h2>Adaptive height RTL</h2>
         <Slider {...settings}>
           <div><h3>1</h3></div>
           <div>

--- a/examples/MultipleItemsRTL.js
+++ b/examples/MultipleItemsRTL.js
@@ -13,7 +13,7 @@ export default class MultipleItems extends Component {
     };
     return (
       <div dir="rtl">
-        <h2> Multiple items </h2>
+        <h2> Multiple items RTL</h2>
         <Slider {...settings}>
           <div><h3>1</h3></div>
           <div><h3>2</h3></div>

--- a/examples/MultipleItemsRTL.js
+++ b/examples/MultipleItemsRTL.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react'
+import Slider from '../src/slider'
+
+export default class MultipleItems extends Component {
+  render() {
+    const settings = {
+      dots: true,
+      rtl: true,
+      infinite: true,
+      speed: 500,
+      slidesToShow: 3,
+      slidesToScroll: 3
+    };
+    return (
+      <div dir="rtl">
+        <h2> Multiple items </h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+          <div><h3>5</h3></div>
+          <div><h3>6</h3></div>
+          <div><h3>7</h3></div>
+          <div><h3>8</h3></div>
+          <div><h3>9</h3></div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/examples/ResponsiveRTL.js
+++ b/examples/ResponsiveRTL.js
@@ -36,7 +36,7 @@ export default class Responsive extends Component {
     };
     return (
       <div dir="rtl">
-        <h2> Responsive </h2>
+        <h2> Responsive RTL</h2>
         <Slider {...settings}>
           <div><h3>1</h3></div>
           <div><h3>2</h3></div>

--- a/examples/ResponsiveRTL.js
+++ b/examples/ResponsiveRTL.js
@@ -1,0 +1,53 @@
+import React, { Component } from 'react'
+import Slider from '../src/slider'
+
+export default class Responsive extends Component {
+  render() {
+    var settings = {
+      dots: true,
+      rtl: true,
+      infinite: false,
+      speed: 500,
+      slidesToShow: 4,
+      slidesToScroll: 4,
+      initialSlide: 0,
+      responsive: [{
+        breakpoint: 1024,
+        settings: {
+          slidesToShow: 3,
+          slidesToScroll: 3,
+          infinite: true,
+          dots: true
+        }
+      }, {
+        breakpoint: 600,
+        settings: {
+          slidesToShow: 2,
+          slidesToScroll: 2,
+          initialSlide: 2
+        }
+      }, {
+        breakpoint: 480,
+        settings: {
+          slidesToShow: 1,
+          slidesToScroll: 1
+        }
+      }]
+    };
+    return (
+      <div dir="rtl">
+        <h2> Responsive </h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+          <div><h3>5</h3></div>
+          <div><h3>6</h3></div>
+          <div><h3>7</h3></div>
+          <div><h3>8</h3></div>
+        </Slider>
+      </div>
+    );
+  }
+};

--- a/examples/SimpleSliderRTL.js
+++ b/examples/SimpleSliderRTL.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react'
+import Slider from '../src/slider'
+
+export default class SimpleSlider extends Component {
+  render() {
+    const settings = {
+      dots: true,
+      rtl: true,
+      infinite: true,
+      speed: 500,
+      slidesToShow: 1,
+      slidesToScroll: 1
+    };
+    return (
+      <div dir="rtl">
+        <h2> Single Item</h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+          <div><h3>5</h3></div>
+          <div><h3>6</h3></div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/examples/SimpleSliderRTL.js
+++ b/examples/SimpleSliderRTL.js
@@ -13,7 +13,7 @@ export default class SimpleSlider extends Component {
     };
     return (
       <div dir="rtl">
-        <h2> Single Item</h2>
+        <h2> Single Item RTL</h2>
         <Slider {...settings}>
           <div><h3>1</h3></div>
           <div><h3>2</h3></div>

--- a/examples/__tests__/MultipleItemsRTL.test.js
+++ b/examples/__tests__/MultipleItemsRTL.test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import MultipleItems from '../MultipleItemsRTL';
+
+/*
+ This is simply to demonstrate that using rtl maintains functionality.
+ Visual verification should be done as the bugs with parent containers with
+ dir="rtl" are quite difficult to verify programmatically.
+ */
+describe('Multiple Items', function () {
+  it('should show first 3 slides', function () {
+    const wrapper = mount(<MultipleItems />);
+    expect(wrapper.find('.slick-slide.slick-active').first().text()).toEqual("1");
+    expect(wrapper.find('.slick-slide.slick-active').at(1).text()).toEqual("2");
+    expect(wrapper.find('.slick-slide.slick-active').last().text()).toEqual("3");
+  });
+  it('should show slides from 4 to 6 when next button is clicked', function () {
+    const wrapper = mount(<MultipleItems />);
+    wrapper.find('.slick-next').simulate('click')
+    expect(wrapper.find('.slick-slide.slick-active').first().text()).toEqual("4");
+    expect(wrapper.find('.slick-slide.slick-active').at(1).text()).toEqual("5");
+    expect(wrapper.find('.slick-slide.slick-active').last().text()).toEqual("6");
+  });
+  it('should show last 3 slides when previous button is clicked', function () {
+    const wrapper = mount(<MultipleItems />);
+    wrapper.find('.slick-prev').simulate('click')
+    expect(wrapper.find('.slick-slide.slick-active').first().text()).toEqual("7");
+    expect(wrapper.find('.slick-slide.slick-active').at(1).text()).toEqual("8");
+    expect(wrapper.find('.slick-slide.slick-active').last().text()).toEqual("9");
+  });
+  it('should show first 3 slides when middle dot is clicked', function () {
+    const wrapper = mount(<MultipleItems />);
+    wrapper.find('.slick-dots button').at(0).simulate('click')
+    expect(wrapper.find('.slick-slide.slick-active').first().text()).toEqual("1");
+    expect(wrapper.find('.slick-slide.slick-active').at(1).text()).toEqual("2");
+    expect(wrapper.find('.slick-slide.slick-active').last().text()).toEqual("3");
+  });
+  it('should show slides from 4 to 6 when middle dot is clicked', function () {
+    const wrapper = mount(<MultipleItems />);
+    wrapper.find('.slick-dots button').at(1).simulate('click')
+    expect(wrapper.find('.slick-slide.slick-active').first().text()).toEqual("4");
+    expect(wrapper.find('.slick-slide.slick-active').at(1).text()).toEqual("5");
+    expect(wrapper.find('.slick-slide.slick-active').last().text()).toEqual("6");
+  });
+  it('should show last 3 slides when last dot is clicked', function () {
+    const wrapper = mount(<MultipleItems />);
+    wrapper.find('.slick-dots button').at(2).simulate('click')
+    expect(wrapper.find('.slick-slide.slick-active').first().text()).toEqual("7");
+    expect(wrapper.find('.slick-slide.slick-active').at(1).text()).toEqual("8");
+    expect(wrapper.find('.slick-slide.slick-active').last().text()).toEqual("9");
+  });
+
+})

--- a/examples/__tests__/SimpleSliderRTL.test.js
+++ b/examples/__tests__/SimpleSliderRTL.test.js
@@ -1,0 +1,161 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import SimpleSlider from '../SimpleSliderRTL';
+import { repeatClicks } from '../../test-helpers';
+import { html as beautify_html } from 'js-beautify'
+
+import { getReactSlickDetails } from '../../__tests__/reactSlickUtils'
+import { getJQuerySlickDetails } from '../../__tests__/jQSlickUtils'
+
+/*
+ This is simply to demonstrate that using rtl maintains functionality.
+ Visual verification should be done as the bugs with parent containers with
+ dir="rtl" are quite difficult to verify programmatically.
+ */
+describe('Simple Slider', function () {
+  it('should have 13 slides (1(preclone) + 6(actual) + 6(postclone))', function () {
+    const wrapper = mount(<SimpleSlider />);
+    expect(wrapper.find('.slick-slide').length).toEqual(13);
+  });
+  it('should have 7 clone slides', function () {
+    const wrapper = mount(<SimpleSlider />);
+    expect(wrapper.find('.slick-cloned').length).toEqual(7);
+  });
+  it('should have 1 active slide', function () {
+    const wrapper = mount(<SimpleSlider />);
+    expect(wrapper.find('.slick-slide.slick-active').length).toEqual(1);
+  });
+  it('should have 6 dots', function () {
+    const wrapper = mount(<SimpleSlider />);
+    expect(wrapper.find('.slick-dots').children().length).toEqual(6);
+  });
+  it('should have 1 active dot', function () {
+    const wrapper = mount(<SimpleSlider />);
+    expect(wrapper.find('.slick-dots .slick-active').length).toEqual(1);
+  });
+  it('should have a prev arrow', function () {
+    const wrapper = mount(<SimpleSlider />);
+    expect(wrapper.find('.slick-prev').length).toEqual(1);
+  });
+  it('should have a next arrow', function () {
+    const wrapper = mount(<SimpleSlider />);
+    expect(wrapper.find('.slick-next').length).toEqual(1);
+  });
+
+  it('should got to second slide when next button is clicked', function () {
+    const wrapper = mount(<SimpleSlider />);
+    wrapper.find('.slick-next').simulate('click')
+    expect(wrapper.find('.slick-slide.slick-active').first().text()).toEqual('2');
+    expect(wrapper.find('.slick-dots .slick-active').length).toEqual(1);
+    expect(wrapper.find('.slick-dots').childAt(1).hasClass('slick-active')).toEqual(true)
+  });
+  it('should goto last slide when prev button is clicked', function () {
+    const wrapper = mount(<SimpleSlider />);
+    wrapper.find('.slick-prev').simulate('click')
+    expect(wrapper.find('.slick-slide.slick-active').first().text()).toEqual('6');
+    expect(wrapper.find('.slick-dots .slick-active').length).toEqual(1);
+    expect(wrapper.find('.slick-dots').childAt(5).hasClass('slick-active')).toEqual(true)
+  })
+  it('should goto 4th slide when 4th dot is clicked', function () {
+    const wrapper = mount(<SimpleSlider />);
+    wrapper.find('.slick-dots button').at(3).simulate('click')
+    expect(wrapper.find('.slick-slide.slick-active').first().text()).toEqual('4');
+    expect(wrapper.find('.slick-dots .slick-active').length).toEqual(1);
+    expect(wrapper.find('.slick-dots').childAt(3).hasClass('slick-active')).toEqual(true)
+  })
+  // it('should come back to 1st slide after 6 clicks on next button', function () {
+  //   // waitForAnimate option is causing problem for this test
+  //   const wrapper = mount(<SimpleSlider />);
+  //   wrapper.find('.slick-next').first().simulate('click').simulate('click')
+  //   // wrapper.find('.slick-prev').first().simulate('click')
+  //   // wrapper.find('.slick-next').first().simulate('click')
+  //   // console.log(nextButton)
+  //   // nextButton.simulate('click').simulate('click')
+  //   // nextButton.simulate('click')
+  //   // repeatClicks(wrapper.find('.slick-next'), 1)
+  //   expect(wrapper.find('.slick-slide.slick-active').first().text()).toEqual('1');
+  //   expect(wrapper.find('.slick-dots .slick-active').length).toEqual(1);
+  //   expect(wrapper.find('.slick-dots').childAt(0).hasClass('slick-active')).toEqual(true)
+  // })
+});
+
+describe("Simple Slider Snapshots", function () {
+  it("slider initial state", function () {
+    const wrapper = mount(<SimpleSlider />);
+    expect(beautify_html(wrapper.html())).toMatchSnapshot()
+  });
+  it("click on next button", function () {
+    const wrapper = mount(<SimpleSlider />);
+    wrapper.find('.slick-next').simulate('click')
+    expect(beautify_html(wrapper.html())).toMatchSnapshot()
+  });
+  it("click on prev button", function () {
+    const wrapper = mount(<SimpleSlider />);
+    wrapper.find('.slick-prev').simulate('click')
+    expect(beautify_html(wrapper.html())).toMatchSnapshot()
+  });
+  it("click on 3rd dot", function () {
+    const wrapper = mount(<SimpleSlider />);
+    wrapper.find('.slick-dots button').at(2).simulate('click')
+    expect(beautify_html(wrapper.html())).toMatchSnapshot()
+  })
+});
+
+export function testWithParams(settings, actions, keys) {
+  let reactDetails = getReactSlickDetails(settings, actions, keys)
+  let jQueryDetails = getJQuerySlickDetails(settings, actions, keys)
+  test('currentSlide', () => {
+    expect(reactDetails.currentSlide).toEqual(jQueryDetails.currentSlide)
+  })
+  test('activeSlides', () => {
+    expect(reactDetails.activeSlides).toEqual(jQueryDetails.activeSlides)
+  })
+  test('allSlides', () => {
+    expect(reactDetails.allSlides).toEqual(jQueryDetails.allSlides)
+  })
+  test('activeSlides', () => {
+    expect(reactDetails.clonedSlides).toEqual(jQueryDetails.clonedSlides)
+  })
+}
+
+describe('Simple Slider React Vs jQuery', () => {
+
+  let settings = {
+    noOfSlides: 5,
+    infinite: true,
+    speed: 0,
+    useCSS: false,
+    slidesToShow: 1,
+    slidesToScroll: 1
+  }
+  let actions = {}
+  let keys = {
+    currentSlide: true,
+    activeSlides: true,
+    clonedSlides: true,
+    allSlides: true,
+    visibleSlides: true
+  }
+
+  // first section
+  testWithParams(settings, actions, keys)
+
+  // second section
+  actions = {
+    clickNext: 6
+  }
+  testWithParams(settings, actions, keys)
+
+  // third section
+  actions = {
+    clickPrev: 6
+  }
+  testWithParams(settings, actions, keys)
+
+  // fourth section
+  actions = {
+    clickSequence: 'nnpnnnnppnnnnnn'
+  }
+  testWithParams(settings, actions, keys)
+
+})

--- a/src/mixins/event-handlers.js
+++ b/src/mixins/event-handlers.js
@@ -263,7 +263,7 @@ var EventHandlers = {
         return true;
       });
 
-      const currentIndex = this.props.rtl === true ? this.state.slideCount - this.state.currentSlide : this.state.currentSlide; 
+      const currentIndex = this.props.rtl === true ? this.state.slideCount - this.state.currentSlide : this.state.currentSlide;
       const slidesTraversed = Math.abs(swipedSlide.dataset.index - currentIndex) || 1;
 
       return slidesTraversed;

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -28,7 +28,7 @@ var helpers = {
     const slideHeight = this.getHeight(slickList.querySelector('[data-index="0"]'));
     const listHeight = slideHeight * props.slidesToShow;
 
-    var currentSlide = props.rtl ? slideCount - 1 - props.initialSlide : props.initialSlide;
+    var currentSlide = props.initialSlide;
 
     this.setState({
       slideCount,
@@ -80,7 +80,7 @@ var helpers = {
     } else {
       this.autoPlay(props.autoplay);
     }
-    
+
     const lazyLoadedList = this.state.lazyLoadedList
     let startIndex, endIndex
     if (props.centerMode) {
@@ -260,10 +260,10 @@ var helpers = {
       finalTargetSlide = animationTargetSlide;
     }
 
-    /* 
+    /*
       stop: critical checkpoint
     */
-   
+
     animationTargetLeft = getTrackLeft(assign({
       slideIndex: animationTargetSlide,
       trackRef: this.track

--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -23,20 +23,22 @@ export var getTrackCSS = function(spec) {
     trackHeight = trackChildren * spec.slideHeight;
   }
 
+  const direction = spec.rtl ? -1 : 1;
+
   var style = {
     opacity: 1,
-    WebkitTransform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
-    transform: !spec.vertical ? 'translate3d(' + spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
+    WebkitTransform: !spec.vertical ? 'translate3d(' + direction * spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
+    transform: !spec.vertical ? 'translate3d(' + direction * spec.left + 'px, 0px, 0px)' : 'translate3d(0px, ' + spec.left + 'px, 0px)',
     transition: '',
     WebkitTransition: '',
-    msTransform: !spec.vertical ? 'translateX(' + spec.left + 'px)' : 'translateY(' + spec.left + 'px)',
+    msTransform: !spec.vertical ? 'translateX(' + direction * spec.left + 'px)' : 'translateY(' + spec.left + 'px)',
   };
   if (spec.fade) {
     style = {
       opacity: 1
     }
   }
-  
+
   if (trackWidth) {
     assign(style, { width: trackWidth });
   }
@@ -75,7 +77,7 @@ export var getTrackLeft = function (spec) {
   checkSpecKeys(spec, [
    'slideIndex', 'trackRef', 'infinite', 'centerMode', 'slideCount', 'slidesToShow',
    'slidesToScroll', 'slideWidth', 'listWidth', 'variableWidth', 'slideHeight']);
-  
+
   const {slideIndex, trackRef, infinite, centerMode, slideCount, slidesToShow,
     slidesToScroll, slideWidth, listWidth, variableWidth, slideHeight, fade, vertical} = spec
 

--- a/src/track.js
+++ b/src/track.js
@@ -12,11 +12,8 @@ var getSlideClasses = (spec) => {
   var slickActive, slickCenter, slickCloned;
   var centerOffset, index;
 
-  if (spec.rtl) { // if we're going right to left, index is reversed
-    index = spec.slideCount - 1 - spec.index;
-  } else { // index of the slide
-    index = spec.index;
-  }
+  index = spec.index;
+
   slickCloned = (index < 0) || (index >= spec.slideCount);
   if (spec.centerMode) {
     centerOffset = Math.floor(spec.slidesToShow / 2);
@@ -134,11 +131,7 @@ var renderSlides = function (spec) {
     }
   });
 
-  if (spec.rtl) {
-    return preCloneSlides.concat(slides, postCloneSlides).reverse();
-  } else {
-    return preCloneSlides.concat(slides, postCloneSlides);
-  }
+  return preCloneSlides.concat(slides, postCloneSlides);
 };
 
 export class Track extends React.Component {


### PR DESCRIPTION
The usage/rendering logic is broken when the component is used inside a html element which has layout direction set to rtl.

Change the `rtl` prop to enable the container usage in an element which has `rtl` enabled. Adding rtl to html element can be done by two ways (html-attribute `dir` or styles `direction`) and both are handled properly.

The downside of this approach is, that the usage of rtl-prop is changed. This, on the other hand should be a depreaction step worth taking. The benefit of being able to use the component without hacks in rtl-layouts is considerable. 

The demos represent the differences usage. Both blocks represent adding direction by different means and should behave identically. 