### PR TITLE
use existing child key if present

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -166,6 +166,7 @@ export default class Slider extends React.Component {
       i += settings.rows * settings.slidesPerRow
     ) {
       let newSlide = [];
+      const childKey = children[i].key;
       for (
         let j = i;
         j < i + settings.rows * settings.slidesPerRow;
@@ -179,7 +180,7 @@ export default class Slider extends React.Component {
           if (k >= children.length) break;
           row.push(
             React.cloneElement(children[k], {
-              key: 100 * i + 10 * j + k,
+              key: childKey !== undefined ? childKey : 100 * i + 10 * j + k,
               tabIndex: -1,
               style: {
                 width: `${100 / settings.slidesPerRow}%`,
@@ -188,16 +189,23 @@ export default class Slider extends React.Component {
             })
           );
         }
-        newSlide.push(<div key={10 * i + j}>{row}</div>);
+        newSlide.push(
+          <div key={childKey !== undefined ? childKey : 10 * i + j}>{row}</div>
+        );
       }
       if (settings.variableWidth) {
         newChildren.push(
-          <div key={i} style={{ width: currentWidth }}>
+          <div
+            key={childKey !== undefined ? childKey : i}
+            style={{ width: currentWidth }}
+          >
             {newSlide}
           </div>
         );
       } else {
-        newChildren.push(<div key={i}>{newSlide}</div>);
+        newChildren.push(
+          <div key={childKey !== undefined ? childKey : i}>{newSlide}</div>
+        );
       }
     }
 


### PR DESCRIPTION
The current logic assumes that users did not specify unique keys for the slides which are children of the Slider component so it generates them manually using indices. I'm using dynamic slides/children however and this leads to problems when I want to unmount a slide at say index position 0 because all subsequent slides will have their index changed and hence have to update. By using the child key (if present) this can be avoided.