### PR TITLE
use dontAnimate argument by default when currentSlide is too high 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slick",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": ["dist", "lib"],

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -20,8 +20,7 @@ import {
   getPreClones,
   getPostClones,
   getTrackLeft,
-  getTrackCSS,
-  canUseDOM
+  getTrackCSS
 } from "./utils/innerSliderUtils";
 
 import { Track } from "./track";

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -589,7 +589,7 @@ export class InnerSlider extends React.Component {
   render = () => {
     var className = classnames("slick-slider", this.props.className, {
       "slick-vertical": this.props.vertical,
-      "slick-initialized": canUseDOM()
+      "slick-initialized": true
     });
     let spec = { ...this.props, ...this.state };
     let trackProps = extractObject(spec, [

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -153,12 +153,15 @@ export class InnerSlider extends React.Component {
     }
     this.updateState(spec, setTrackStyle, () => {
       if (this.state.currentSlide >= React.Children.count(nextProps.children)) {
-        this.changeSlide({
-          message: "index",
-          index:
-            React.Children.count(nextProps.children) - nextProps.slidesToShow,
-          currentSlide: this.state.currentSlide
-        });
+        this.changeSlide(
+          {
+            message: "index",
+            index:
+              React.Children.count(nextProps.children) - nextProps.slidesToShow,
+            currentSlide: this.state.currentSlide
+          },
+          true
+        );
       }
       if (nextProps.autoplay) {
         this.autoPlay("update");


### PR DESCRIPTION
I'm using dynamic slides/children and encountered the following behaviour. Say for example that I'm on slide 3 and I want to delete slide 2 while staying on slide 3. This is the only scenario I can think of where the condition in https://github.com/akiran/react-slick/blob/master/src/inner-slider.js#L155 would resolve to true.
Even though technically the user is then going from slide 3 to 2, the user doesn't (or shouldn't) really notice. For the user it should look like they are staying on the same page and only the number of available slides has changed. That's why I set the dontAnimate parameter to true for this case. If I'm overlooking a valid use case where this behaviour is not intended then I could introduce a new config flag to make this configurable.