### PR TITLE
Reset clickable to true afterChange

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -399,6 +399,7 @@ export class InnerSlider extends React.Component {
           this.callbackTimers.push(
             setTimeout(() => this.setState({ animating }), 10)
           );
+          this.clickable = true;
           afterChange && afterChange(state.currentSlide);
           delete this.animationEndCallback;
         });


### PR DESCRIPTION
Reset clickable to true afterChange, Otherwise click event on slider will not be emited.