### PR TITLE
Adjust track width calculation for variable width slides

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -48,7 +48,7 @@ export const getSwipeDirection = (touchObject, verticalSwiping = false) => {
   xDist = touchObject.startX - touchObject.curX;
   yDist = touchObject.startY - touchObject.curY;
   r = Math.atan2(yDist, xDist);
-  swipeAngle = Math.round(r * 180 / Math.PI);
+  swipeAngle = Math.round((r * 180) / Math.PI);
   if (swipeAngle < 0) {
     swipeAngle = 360 - Math.abs(swipeAngle);
   }
@@ -195,7 +195,7 @@ export const slideHandler = spec => {
       finalSlide = animationSlide + slideCount;
       if (!infinite) finalSlide = 0;
       else if (slideCount % slidesToScroll !== 0)
-        finalSlide = slideCount - slideCount % slidesToScroll;
+        finalSlide = slideCount - (slideCount % slidesToScroll);
     } else if (!canGoNext(spec) && animationSlide > currentSlide) {
       animationSlide = finalSlide = currentSlide;
     } else if (centerMode && animationSlide >= slideCount) {
@@ -265,7 +265,8 @@ export const changeSlide = (spec, options) => {
     slideOffset = indexOffset === 0 ? slidesToScroll : indexOffset;
     targetSlide = currentSlide + slideOffset;
     if (lazyLoad && !infinite) {
-      targetSlide = (currentSlide + slidesToScroll) % slideCount + indexOffset;
+      targetSlide =
+        ((currentSlide + slidesToScroll) % slideCount) + indexOffset;
     }
   } else if (options.message === "dots") {
     // Click on dots
@@ -565,9 +566,12 @@ export const getTrackCSS = spec => {
     "slideWidth"
   ]);
   let trackWidth, trackHeight;
+  const variableWidthMax = 5000; // Arbitrary width, mirrors what is used by Slick Carousel
   const trackChildren = spec.slideCount + 2 * spec.slidesToShow;
-  if (!spec.vertical) {
+  if (!spec.vertical && !spec.variableWidth) {
     trackWidth = getTotalSlides(spec) * spec.slideWidth;
+  } else if (!spec.vertical && spec.variableWidth) {
+    trackWidth = trackChildren * variableWidthMax;
   } else {
     trackHeight = trackChildren * spec.slideHeight;
   }
@@ -704,7 +708,7 @@ export const getTrackLeft = spec => {
       slideCount % slidesToScroll !== 0 &&
       slideIndex + slidesToScroll > slideCount
     ) {
-      slidesToOffset = slidesToShow - slideCount % slidesToScroll;
+      slidesToOffset = slidesToShow - (slideCount % slidesToScroll);
     }
     if (centerMode) {
       slidesToOffset = parseInt(slidesToShow / 2);


### PR DESCRIPTION
Fixes #1304 

For variableWidth=true, the typical calculation of trackWidth does not work (images do not necessarily take up an equal amount of the viewable area in the carousel). Slick Carousel gets around this by using an arbitrarily large slideWidth (5000).

https://github.com/kenwheeler/slick/blob/master/slick/slick.js#L2081