### PR TITLE
Finite variable width slider slides always fill the display area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/akiran/react-slick/tree/HEAD)
 
-## 0.24.0
+## 0.24.1
 
 **Release Changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased](https://github.com/akiran/react-slick/tree/HEAD)
 
+## 0.24.2
+
+**Release Changes**
+
+- Bug fixes
+  - It removes the need of slidesToscroll/slidesToShow === 1
+  - It fixes the issue of right snapping when the images inside the gallery doesn't fill the sliding window.
+
 ## 0.24.1
 
 **Release Changes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 ## [Unreleased](https://github.com/akiran/react-slick/tree/HEAD)
 
+## 0.24.0
+
+**Release Changes**
+
+- added prop to avoid having a right blank padding when getting to the last elements and they don't fill up the entire gallery. See [issue #1334](https://github.com/akiran/react-slick/issues/1334)
+
 ## 0.22.0
 
 **Release Changes**
 
 - Internal Changes
+
   - converted InnerSlider from createReactClass object to ES6 class
   - removed all the mixins, created classMethods and pure utility functions instead
   - changed autoplay from setTimeout to setInterval
@@ -36,12 +43,12 @@
   - fixed bugs due to uncleared callback timers
   - fixed update issues on just slider resize
 
-
 ## 0.21.0
 
 **Release Changes**
 
 - Fixed issues
+
   - dataset undefined error in case of swipeToSlide but finite slides
   - slideWidth issue by transform scale
   - variableWidth + finite alignment problems
@@ -50,6 +57,7 @@
   - fixed breaking of animation on setState
 
 - Mixins to Pure Functions
+
   - getWidth, getHeight
   - swipeDirection
   - initialize, update
@@ -75,7 +83,6 @@
 - implemented reInit event
 - implemented onSwipe event and documented edgeEvent
 
-
 ## 0.19.0
 
 **Release Changes**
@@ -92,7 +99,6 @@ Following are the changes to be mentioned:
 - responsive lazyloading bug fixed
 - increased verticalswiping resistance from 4 to 10
 
-
 ## 0.18.0
 
 **Major Changes:**
@@ -104,18 +110,17 @@ Following are the changes to be mentioned:
 - Modified logic for updating lazyLoadedList, earlier there were some whitespaces at ends, now they're gone
 - Fixed getTrackLeft issue for slideCount=1
 
-
 ## 0.17.1
 
 **Major Changes**
 
-* Enforced some settings in specific configurations like:
-  - `slidesToScroll = 1` *when fade is true*
-  - `slidesToScroll = 1` *when centerMode is true*
-  - `slidesToShow = 1` *when fade is true*
+- Enforced some settings in specific configurations like:
 
-* Changed the number of clones (preclones and postclones), that fixed couple of issues like blank spaces after last slide and/or before first slide which occurred in several cases.
+  - `slidesToScroll = 1` _when fade is true_
+  - `slidesToScroll = 1` _when centerMode is true_
+  - `slidesToShow = 1` _when fade is true_
 
+- Changed the number of clones (preclones and postclones), that fixed couple of issues like blank spaces after last slide and/or before first slide which occurred in several cases.
 
 **Minor Changes**
 

--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -32,6 +32,7 @@ import CustomPaging from '../examples/CustomPaging'
 import CustomSlides from '../examples/CustomSlides'
 import AsNavFor from '../examples/AsNavFor'
 import AppendDots from '../examples/AppendDots'
+import NoRightPadding from "../examples/NoRightPadding";
 
 export default class App extends React.Component {
   render() {
@@ -66,6 +67,7 @@ export default class App extends React.Component {
         <VerticalSwipeToSlide />
         <AsNavFor />
         <AppendDots />
+        <NoRightPadding />
       </div>
     );
   }

--- a/examples/NoRightPadding.js
+++ b/examples/NoRightPadding.js
@@ -1,0 +1,35 @@
+import React, { Component } from "react";
+import Slider from "../src/slider";
+import { baseUrl } from "./config";
+
+export default class NoRightPadding extends Component {
+  render() {
+    const settings = {
+      dots: true,
+      infinite: false,
+      speed: 500,
+      slidesToShow: 1,
+      slidesToScroll: 1,
+      noRightPadding: true
+    };
+    return (
+      <div>
+        <h2>No Right Padding</h2>
+        <Slider {...settings}>
+          <div>
+            <img src={baseUrl + "/abstract01.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract02.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract03.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract04.jpg"} />
+          </div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "react-slick",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "description": " React port of slick carousel",
   "main": "./lib",
-  "files": ["dist", "lib"],
+  "files": [
+    "dist",
+    "lib"
+  ],
   "scripts": {
     "start": "gulp server",
     "build": "gulp clean && gulp sass && gulp copy && webpack",
@@ -11,8 +14,7 @@
     "test": "eslint src && jest",
     "test:watch": "jest --watch",
     "lint": "eslint src",
-    "gen":
-      "node examples/scripts/generateExampleConfigs.js && node examples/scripts/generateExamples.js && xdg-open docs/jquery.html",
+    "gen": "node examples/scripts/generateExampleConfigs.js && node examples/scripts/generateExamples.js && xdg-open docs/jquery.html",
     "precommit": "lint-staged"
   },
   "author": "Kiran Abburi",
@@ -90,20 +92,27 @@
     "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0"
   },
   "jest": {
-    "setupFiles": ["./test-setup.js"],
+    "setupFiles": [
+      "./test-setup.js"
+    ],
     "testPathIgnorePatterns": [
       "/__tests__/scripts.js",
       "/__tests__/testUtils.js"
     ]
   },
   "lint-staged": {
-    "*.{js,json,md}": ["prettier --write", "git add"]
+    "*.{js,json,md}": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "npmName": "react-slick",
   "npmFileMap": [
     {
       "basePath": "/dist/",
-      "files": ["*.js"]
+      "files": [
+        "*.js"
+      ]
     }
   ],
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slick",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slick",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -25,6 +25,7 @@ var defaultProps = {
   initialSlide: 0,
   lazyLoad: null,
   nextArrow: null,
+  noRightPadding: false,
   onEdge: null,
   onInit: null,
   onLazyLoadError: null,

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -276,15 +276,15 @@ export class InnerSlider extends React.Component {
     let childrenCount = React.Children.count(this.props.children);
     const spec = { ...this.props, ...this.state, slideCount: childrenCount };
     let slideCount = getPreClones(spec) + getPostClones(spec) + childrenCount;
-    let trackWidth = 100 / this.props.slidesToShow * slideCount;
+    let trackWidth = (100 / this.props.slidesToShow) * slideCount;
     let slideWidth = 100 / slideCount;
     let trackLeft =
-      -slideWidth *
-      (getPreClones(spec) + this.state.currentSlide) *
-      trackWidth /
+      (-slideWidth *
+        (getPreClones(spec) + this.state.currentSlide) *
+        trackWidth) /
       100;
     if (this.props.centerMode) {
-      trackLeft += (100 - slideWidth * trackWidth / 100) / 2;
+      trackLeft += (100 - (slideWidth * trackWidth) / 100) / 2;
     }
     let trackStyle = {
       width: trackWidth + "%",
@@ -612,6 +612,7 @@ export class InnerSlider extends React.Component {
       "trackStyle",
       "variableWidth",
       "unslick",
+      "noRightPadding",
       "centerPadding"
     ]);
     const { pauseOnHover } = this.props;

--- a/src/slider.js
+++ b/src/slider.js
@@ -136,25 +136,8 @@ export default class Slider extends React.Component {
       settings.slidesToScroll = 1;
     }
 
-    // force showing one slide, scrolling by one, and finite scrolling if the noRightPadding mode is on
+    // force showing finite scrolling if the noRightPadding mode is on
     if (settings.noRightPadding) {
-      if (settings.slidesToShow > 1 && process.env.NODE_ENV !== "production") {
-        console.warn(
-          `slidesToShow should be equal to 1 when noRightPadding is true, you're using ${
-            settings.slidesToShow
-          }`
-        );
-      }
-      if (
-        settings.slidesToScroll > 1 &&
-        process.env.NODE_ENV !== "production"
-      ) {
-        console.warn(
-          `slidesToScroll should be equal to 1 when noRightPadding is true, you're using ${
-            settings.slidesToScroll
-          }`
-        );
-      }
       if (settings.infinite && process.env.NODE_ENV !== "production") {
         console.warn(
           `infinite should be false when noRightPadding is true, you're using ${
@@ -162,8 +145,6 @@ export default class Slider extends React.Component {
           }`
         );
       }
-      settings.slidesToShow = 1;
-      settings.slidesToScroll = 1;
       settings.infinite = false;
     }
 

--- a/src/slider.js
+++ b/src/slider.js
@@ -136,6 +136,37 @@ export default class Slider extends React.Component {
       settings.slidesToScroll = 1;
     }
 
+    // force showing one slide, scrolling by one, and finite scrolling if the noRightPadding mode is on
+    if (settings.noRightPadding) {
+      if (settings.slidesToShow > 1 && process.env.NODE_ENV !== "production") {
+        console.warn(
+          `slidesToShow should be equal to 1 when noRightPadding is true, you're using ${
+            settings.slidesToShow
+          }`
+        );
+      }
+      if (
+        settings.slidesToScroll > 1 &&
+        process.env.NODE_ENV !== "production"
+      ) {
+        console.warn(
+          `slidesToScroll should be equal to 1 when noRightPadding is true, you're using ${
+            settings.slidesToScroll
+          }`
+        );
+      }
+      if (settings.infinite && process.env.NODE_ENV !== "production") {
+        console.warn(
+          `infinite should be false when noRightPadding is true, you're using ${
+            settings.infinite
+          }`
+        );
+      }
+      settings.slidesToShow = 1;
+      settings.slidesToScroll = 1;
+      settings.infinite = false;
+    }
+
     // makes sure that children is an array, even when there is only 1 child
     let children = React.Children.toArray(this.props.children);
 

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -48,7 +48,7 @@ export const getSwipeDirection = (touchObject, verticalSwiping = false) => {
   xDist = touchObject.startX - touchObject.curX;
   yDist = touchObject.startY - touchObject.curY;
   r = Math.atan2(yDist, xDist);
-  swipeAngle = Math.round(r * 180 / Math.PI);
+  swipeAngle = Math.round((r * 180) / Math.PI);
   if (swipeAngle < 0) {
     swipeAngle = 360 - Math.abs(swipeAngle);
   }
@@ -195,7 +195,7 @@ export const slideHandler = spec => {
       finalSlide = animationSlide + slideCount;
       if (!infinite) finalSlide = 0;
       else if (slideCount % slidesToScroll !== 0)
-        finalSlide = slideCount - slideCount % slidesToScroll;
+        finalSlide = slideCount - (slideCount % slidesToScroll);
     } else if (!canGoNext(spec) && animationSlide > currentSlide) {
       animationSlide = finalSlide = currentSlide;
     } else if (centerMode && animationSlide >= slideCount) {
@@ -265,7 +265,8 @@ export const changeSlide = (spec, options) => {
     slideOffset = indexOffset === 0 ? slidesToScroll : indexOffset;
     targetSlide = currentSlide + slideOffset;
     if (lazyLoad && !infinite) {
-      targetSlide = (currentSlide + slidesToScroll) % slideCount + indexOffset;
+      targetSlide =
+        ((currentSlide + slidesToScroll) % slideCount) + indexOffset;
     }
   } else if (options.message === "dots") {
     // Click on dots
@@ -655,6 +656,7 @@ export const getTrackLeft = spec => {
     "slideWidth",
     "listWidth",
     "variableWidth",
+    "noRightPadding",
     "slideHeight"
   ]);
 
@@ -669,6 +671,7 @@ export const getTrackLeft = spec => {
     slideWidth,
     listWidth,
     variableWidth,
+    noRightPadding,
     slideHeight,
     fade,
     vertical
@@ -704,7 +707,7 @@ export const getTrackLeft = spec => {
       slideCount % slidesToScroll !== 0 &&
       slideIndex + slidesToScroll > slideCount
     ) {
-      slidesToOffset = slidesToShow - slideCount % slidesToScroll;
+      slidesToOffset = slidesToShow - (slideCount % slidesToScroll);
     }
     if (centerMode) {
       slidesToOffset = parseInt(slidesToShow / 2);
@@ -725,6 +728,22 @@ export const getTrackLeft = spec => {
     targetSlideIndex = slideIndex + getPreClones(spec);
     targetSlide = trackElem && trackElem.childNodes[targetSlideIndex];
     targetLeft = targetSlide ? targetSlide.offsetLeft * -1 : 0;
+    if (noRightPadding) {
+      let widthUntilListRightEnd = 0;
+      for (
+        let slide = targetSlideIndex;
+        slide < trackElem.childNodes.length;
+        slide++
+      ) {
+        widthUntilListRightEnd +=
+          trackElem &&
+          trackElem.children[slide] &&
+          trackElem.children[slide].offsetWidth;
+      }
+      if (widthUntilListRightEnd < listWidth) {
+        targetLeft += listWidth - widthUntilListRightEnd;
+      }
+    }
     if (centerMode === true) {
       targetSlideIndex = infinite
         ? slideIndex + getPreClones(spec)

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -742,6 +742,9 @@ export const getTrackLeft = spec => {
       }
       if (widthUntilListRightEnd < listWidth) {
         targetLeft += listWidth - widthUntilListRightEnd;
+        if (targetLeft >= 0) {
+          targetLeft = 0;
+        }
       }
     }
     if (centerMode === true) {


### PR DESCRIPTION
Fixes #1334

I've added some logic to snap the right side of the last slide to the right side of the scrolling window.