### PR TITLE
Fix playing if autoplay prop is changed

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -276,15 +276,15 @@ export class InnerSlider extends React.Component {
     let childrenCount = React.Children.count(this.props.children);
     const spec = { ...this.props, ...this.state, slideCount: childrenCount };
     let slideCount = getPreClones(spec) + getPostClones(spec) + childrenCount;
-    let trackWidth = 100 / this.props.slidesToShow * slideCount;
+    let trackWidth = (100 / this.props.slidesToShow) * slideCount;
     let slideWidth = 100 / slideCount;
     let trackLeft =
-      -slideWidth *
-      (getPreClones(spec) + this.state.currentSlide) *
-      trackWidth /
+      (-slideWidth *
+        (getPreClones(spec) + this.state.currentSlide) *
+        trackWidth) /
       100;
     if (this.props.centerMode) {
-      trackLeft += (100 - slideWidth * trackWidth / 100) / 2;
+      trackLeft += (100 - (slideWidth * trackWidth) / 100) / 2;
     }
     let trackStyle = {
       width: trackWidth + "%",
@@ -531,11 +531,7 @@ export class InnerSlider extends React.Component {
     }
     const autoplaying = this.state.autoplaying;
     if (playType === "update") {
-      if (
-        autoplaying === "hovered" ||
-        autoplaying === "focused" ||
-        autoplaying === "paused"
-      ) {
+      if (autoplaying === "hovered" || autoplaying === "focused") {
         return;
       }
     } else if (playType === "leave") {


### PR DESCRIPTION
When the `autoplay` prop is changed from `false` to `true`, the autoplay functionality didn’t re-initialize and the slider wasn’t re-rendered.

With this PR, changing the `autoplay` prop from `false` to `true` makes autoplay work again as expected. It doesn’t seem to break anything else. I don’t have a full overview over the code base, so make sure this change doesn’t introduce other issues.