### PR TITLE
Fix adaptiveHeight logic for multiple on page sliders

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -296,7 +296,7 @@ export class InnerSlider extends React.Component {
     });
   };
   checkImagesLoad = () => {
-    let images = document.querySelectorAll(".slick-slide img");
+    let images = this.list.querySelectorAll(".slick-slide img");
     let imagesCount = images.length,
       loadedCount = 0;
     Array.prototype.forEach.call(images, image => {


### PR DESCRIPTION
Closes #1356 

query img elements from this and not from global document to ensure only image.onload of children to the current slider are set