### PR TITLE
fix null error when innerSlider is missing

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -390,6 +390,7 @@ export class InnerSlider extends React.Component {
     onLazyLoad && slidesToLoad.length > 0 && onLazyLoad(slidesToLoad);
     this.setState(state, () => {
       asNavFor &&
+        asNavFor.innerSlider &&
         asNavFor.innerSlider.state.currentSlide !== currentSlide &&
         asNavFor.innerSlider.slideHandler(index);
       if (!nextState) return;


### PR DESCRIPTION
In some cases, the slider content may be cleared and repopulated with
new values while the parent component is changing signficantly.
Sometimes (but not always!) during these changes, the temporary absence
of the `innerSlider` from `asNavFor` would break browser rendering,
requiring a full page refresh to fix.

See [issue #1184](https://github.com/akiran/react-slick/issues/1184)

**Note**: I tried running the test suite locally, but even on the unmodified master branch and the 0.23.1 tag, there are a large number of test failures, so I can't be positive before opening this PR whether the tests are working with this change.