### PR TITLE
fix: make multiple visible slides active when sliding to the last slides

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -29,9 +29,13 @@ var getSlideClasses = spec => {
       slickActive = true;
     }
   } else {
-    slickActive =
+    slickActive = (
       spec.currentSlide <= index &&
-      index < spec.currentSlide + spec.slidesToShow;
+      index < spec.currentSlide + spec.slidesToShow
+    ) || (
+      spec.currentSlide >= spec.slideCount - spec.slidesToShow &&
+      index >= spec.slideCount - spec.slidesToShow
+    );
   }
   let slickCurrent = index === spec.currentSlide;
   return {


### PR DESCRIPTION
Truly closes https://github.com/akiran/react-slick/issues/764

Added check for edge case, when current slide is in the last slides area. Sorry hadn't much time to review tests, because they are already broken, here is before/after, thus making PR against the dev, you can leave it opened.

Before:
```
Test Suites: 8 failed, 2 skipped, 10 passed, 18 of 20 total
Tests:       65 failed, 5 skipped, 46 passed, 116 total
Snapshots:   5 failed, 19 passed, 24 total
```

After:
```
Test Suites: 12 failed, 2 skipped, 6 passed, 18 of 20 total
Tests:       66 failed, 5 skipped, 40 passed, 111 total
Snapshots:   8 failed, 14 passed, 22 total
```