### PR TITLE
Click events are now working on active slides

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -58,6 +58,7 @@ var getSlideStyle = function(spec) {
       style.left = -spec.index * parseInt(spec.slideWidth);
     }
     style.opacity = spec.currentSlide === spec.index ? 1 : 0;
+    style.visibility = spec.currentSlide === spec.index ? 'visible' : 'hidden';
     style.transition =
       "opacity " +
       spec.speed +


### PR DESCRIPTION
Click events are now working for slides that are active by adding `visibility: hidden` to the inactive slides and `visibility: visible` to the active ones when they're in fade mode