### PR TITLE
Reset height to auto for vertical carousels when unslick is true

### DIFF
--- a/__tests__/testUtils.js
+++ b/__tests__/testUtils.js
@@ -46,11 +46,7 @@ export function createInnerSlider({ noOfSlides, ...settings }) {
   const children = React.Children.toArray(
     createReactSliderChildren(noOfSlides)
   );
-  return (
-    <InnerSlider {...settings} ref={slider => (this.innerSlider = slider)}>
-      {children}
-    </InnerSlider>
-  );
+  return <InnerSlider {...settings}>{children}</InnerSlider>;
 }
 
 export function createInnerSliderWrapper(settings) {

--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -1,42 +1,43 @@
-'use strict';
+"use strict";
 
-import React from 'react';
-import Slider from '../src/slider';
+import React from "react";
+import Slider from "../src/slider";
 
-import SimpleSlider from '../examples/SimpleSlider'
-import SlideChangeHooks from '../examples/SlideChangeHooks'
-import MultipleItems from '../examples/MultipleItems'
-import MultipleRows from '../examples/MultipleRows'
-import Responsive from '../examples/Responsive'
-import Resizable from '../examples/Resizable'
-import UnevenSetsInfinite from '../examples/UnevenSetsInfinite'
-import UnevenSetsFinite from '../examples/UnevenSetsFinite'
-import CenterMode from '../examples/CenterMode'
-import FocusOnSelect from '../examples/FocusOnSelect'
-import AutoPlay from '../examples/AutoPlay'
-import AutoPlayMethods from '../examples/AutoPlayMethods'
-import PauseOnHover from '../examples/PauseOnHover'
-import Rtl from '../examples/Rtl'
-import VariableWidth from '../examples/VariableWidth'
-import AdaptiveHeight from '../examples/AdaptiveHeight'
-import LazyLoad from '../examples/LazyLoad'
-import Fade from '../examples/Fade'
-import SlickGoTo from '../examples/SlickGoTo'
-import CustomArrows from '../examples/CustomArrows'
-import PreviousNextMethods from '../examples/PreviousNextMethods'
-import DynamicSlides  from '../examples/DynamicSlides'
-import VerticalMode  from '../examples/VerticalMode'
-import SwipeToSlide from '../examples/SwipeToSlide'
-import VerticalSwipeToSlide from '../examples/VerticalSwipeToSlide'
-import CustomPaging from '../examples/CustomPaging'
-import CustomSlides from '../examples/CustomSlides'
-import AsNavFor from '../examples/AsNavFor'
-import AppendDots from '../examples/AppendDots'
+import SimpleSlider from "../examples/SimpleSlider";
+import SlideChangeHooks from "../examples/SlideChangeHooks";
+import MultipleItems from "../examples/MultipleItems";
+import MultipleRows from "../examples/MultipleRows";
+import Responsive from "../examples/Responsive";
+import Resizable from "../examples/Resizable";
+import UnevenSetsInfinite from "../examples/UnevenSetsInfinite";
+import UnevenSetsFinite from "../examples/UnevenSetsFinite";
+import CenterMode from "../examples/CenterMode";
+import FocusOnSelect from "../examples/FocusOnSelect";
+import AutoPlay from "../examples/AutoPlay";
+import AutoPlayMethods from "../examples/AutoPlayMethods";
+import PauseOnHover from "../examples/PauseOnHover";
+import Rtl from "../examples/Rtl";
+import VariableWidth from "../examples/VariableWidth";
+import AdaptiveHeight from "../examples/AdaptiveHeight";
+import LazyLoad from "../examples/LazyLoad";
+import Fade from "../examples/Fade";
+import SlickGoTo from "../examples/SlickGoTo";
+import CustomArrows from "../examples/CustomArrows";
+import PreviousNextMethods from "../examples/PreviousNextMethods";
+import DynamicSlides from "../examples/DynamicSlides";
+import VerticalMode from "../examples/VerticalMode";
+import VerticalModeMoreSlidesToShow from "../examples/VerticalModeMoreSlidesToShow";
+import SwipeToSlide from "../examples/SwipeToSlide";
+import VerticalSwipeToSlide from "../examples/VerticalSwipeToSlide";
+import CustomPaging from "../examples/CustomPaging";
+import CustomSlides from "../examples/CustomSlides";
+import AsNavFor from "../examples/AsNavFor";
+import AppendDots from "../examples/AppendDots";
 
 export default class App extends React.Component {
   render() {
     return (
-      <div className='content'>
+      <div className="content">
         <SimpleSlider />
         <MultipleItems />
         <MultipleRows />
@@ -62,6 +63,7 @@ export default class App extends React.Component {
         <PreviousNextMethods />
         <DynamicSlides />
         <VerticalMode />
+        <VerticalModeMoreSlidesToShow />
         <SwipeToSlide />
         <VerticalSwipeToSlide />
         <AsNavFor />

--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -1,43 +1,43 @@
-"use strict";
+'use strict';
 
-import React from "react";
-import Slider from "../src/slider";
+import React from 'react';
+import Slider from '../src/slider';
 
-import SimpleSlider from "../examples/SimpleSlider";
-import SlideChangeHooks from "../examples/SlideChangeHooks";
-import MultipleItems from "../examples/MultipleItems";
-import MultipleRows from "../examples/MultipleRows";
-import Responsive from "../examples/Responsive";
-import Resizable from "../examples/Resizable";
-import UnevenSetsInfinite from "../examples/UnevenSetsInfinite";
-import UnevenSetsFinite from "../examples/UnevenSetsFinite";
-import CenterMode from "../examples/CenterMode";
-import FocusOnSelect from "../examples/FocusOnSelect";
-import AutoPlay from "../examples/AutoPlay";
-import AutoPlayMethods from "../examples/AutoPlayMethods";
-import PauseOnHover from "../examples/PauseOnHover";
-import Rtl from "../examples/Rtl";
-import VariableWidth from "../examples/VariableWidth";
-import AdaptiveHeight from "../examples/AdaptiveHeight";
-import LazyLoad from "../examples/LazyLoad";
-import Fade from "../examples/Fade";
-import SlickGoTo from "../examples/SlickGoTo";
-import CustomArrows from "../examples/CustomArrows";
-import PreviousNextMethods from "../examples/PreviousNextMethods";
-import DynamicSlides from "../examples/DynamicSlides";
-import VerticalMode from "../examples/VerticalMode";
-import VerticalModeMoreSlidesToShow from "../examples/VerticalModeMoreSlidesToShow";
-import SwipeToSlide from "../examples/SwipeToSlide";
-import VerticalSwipeToSlide from "../examples/VerticalSwipeToSlide";
-import CustomPaging from "../examples/CustomPaging";
-import CustomSlides from "../examples/CustomSlides";
-import AsNavFor from "../examples/AsNavFor";
-import AppendDots from "../examples/AppendDots";
+import SimpleSlider from '../examples/SimpleSlider';
+import SlideChangeHooks from '../examples/SlideChangeHooks';
+import MultipleItems from '../examples/MultipleItems';
+import MultipleRows from '../examples/MultipleRows';
+import Responsive from '../examples/Responsive';
+import Resizable from '../examples/Resizable';
+import UnevenSetsInfinite from '../examples/UnevenSetsInfinite';
+import UnevenSetsFinite from '../examples/UnevenSetsFinite';
+import CenterMode from '../examples/CenterMode';
+import FocusOnSelect from '../examples/FocusOnSelect';
+import AutoPlay from '../examples/AutoPlay';
+import AutoPlayMethods from '../examples/AutoPlayMethods';
+import PauseOnHover from '../examples/PauseOnHover';
+import Rtl from '../examples/Rtl';
+import VariableWidth from '../examples/VariableWidth';
+import AdaptiveHeight from '../examples/AdaptiveHeight';
+import LazyLoad from '../examples/LazyLoad';
+import Fade from '../examples/Fade';
+import SlickGoTo from '../examples/SlickGoTo';
+import CustomArrows from '../examples/CustomArrows';
+import PreviousNextMethods from '../examples/PreviousNextMethods';
+import DynamicSlides from '../examples/DynamicSlides';
+import VerticalMode from '../examples/VerticalMode';
+import VerticalModeMoreSlidesToShow from '../examples/VerticalModeMoreSlidesToShow';
+import SwipeToSlide from '../examples/SwipeToSlide';
+import VerticalSwipeToSlide from '../examples/VerticalSwipeToSlide';
+import CustomPaging from '../examples/CustomPaging';
+import CustomSlides from '../examples/CustomSlides';
+import AsNavFor from '../examples/AsNavFor';
+import AppendDots from '../examples/AppendDots';
 
 export default class App extends React.Component {
   render() {
     return (
-      <div className="content">
+      <div className='content'>
         <SimpleSlider />
         <MultipleItems />
         <MultipleRows />

--- a/examples/VerticalModeMoreSlidesToShow.js
+++ b/examples/VerticalModeMoreSlidesToShow.js
@@ -1,0 +1,39 @@
+import React, { Component } from "react";
+import Slider from "../src/slider";
+
+export default class VerticalModeMoreSlidesToShow extends Component {
+  render() {
+    const settings = {
+      dots: true,
+      infinite: false,
+      slidesToShow: 4,
+      slidesToScroll: 1,
+      vertical: true,
+      verticalSwiping: true,
+      beforeChange: function(currentSlide, nextSlide) {
+        console.log("before change", currentSlide, nextSlide);
+      },
+      afterChange: function(currentSlide) {
+        console.log("after change", currentSlide);
+      }
+    };
+    return (
+      <div>
+        <h2>
+          Vertical Mode with Greater <code>slidesToShow</code> than Slides
+        </h2>
+        <Slider {...settings}>
+          <div>
+            <h3>1</h3>
+          </div>
+          <div>
+            <h3>2</h3>
+          </div>
+          <div>
+            <h3>3</h3>
+          </div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/examples/__tests__/__snapshots__/CenterMode.test.js.snap
+++ b/examples/__tests__/__snapshots__/CenterMode.test.js.snap
@@ -119,7 +119,8 @@ exports[`CenterMode Tests Activity test 1`] = `
                     </div>
                 </div>
             </div>
-        </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button></div>
+        </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button>
+    </div>
 </div>"
 `;
 
@@ -242,7 +243,8 @@ exports[`CenterMode Tests Counting test 1`] = `
                     </div>
                 </div>
             </div>
-        </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button></div>
+        </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button>
+    </div>
 </div>"
 `;
 
@@ -365,6 +367,7 @@ exports[`CenterMode Tests Positioning test 1`] = `
                     </div>
                 </div>
             </div>
-        </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button></div>
+        </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button>
+    </div>
 </div>"
 `;

--- a/examples/__tests__/__snapshots__/FocusOnSelect.test.js.snap
+++ b/examples/__tests__/__snapshots__/FocusOnSelect.test.js.snap
@@ -113,7 +113,8 @@ exports[`FocusOnSelect Tests Activity Test 1`] = `
                     </div>
                 </div>
             </div>
-        </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button></div>
+        </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button>
+    </div>
 </div>"
 `;
 
@@ -230,6 +231,7 @@ exports[`FocusOnSelect Tests Activity Test 2`] = `
                     </div>
                 </div>
             </div>
-        </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button></div>
+        </div><button type=\\"button\\" data-role=\\"none\\" class=\\"slick-arrow slick-next\\" style=\\"display: block;\\"> Next</button>
+    </div>
 </div>"
 `;

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -276,15 +276,15 @@ export class InnerSlider extends React.Component {
     let childrenCount = React.Children.count(this.props.children);
     const spec = { ...this.props, ...this.state, slideCount: childrenCount };
     let slideCount = getPreClones(spec) + getPostClones(spec) + childrenCount;
-    let trackWidth = (100 / this.props.slidesToShow) * slideCount;
+    let trackWidth = 100 / this.props.slidesToShow * slideCount;
     let slideWidth = 100 / slideCount;
     let trackLeft =
-      (-slideWidth *
-        (getPreClones(spec) + this.state.currentSlide) *
-        trackWidth) /
+      -slideWidth *
+      (getPreClones(spec) + this.state.currentSlide) *
+      trackWidth /
       100;
     if (this.props.centerMode) {
-      trackLeft += (100 - (slideWidth * trackWidth) / 100) / 2;
+      trackLeft += (100 - slideWidth * trackWidth / 100) / 2;
     }
     let trackStyle = {
       width: trackWidth + "%",

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -276,15 +276,15 @@ export class InnerSlider extends React.Component {
     let childrenCount = React.Children.count(this.props.children);
     const spec = { ...this.props, ...this.state, slideCount: childrenCount };
     let slideCount = getPreClones(spec) + getPostClones(spec) + childrenCount;
-    let trackWidth = 100 / this.props.slidesToShow * slideCount;
+    let trackWidth = (100 / this.props.slidesToShow) * slideCount;
     let slideWidth = 100 / slideCount;
     let trackLeft =
-      -slideWidth *
-      (getPreClones(spec) + this.state.currentSlide) *
-      trackWidth /
+      (-slideWidth *
+        (getPreClones(spec) + this.state.currentSlide) *
+        trackWidth) /
       100;
     if (this.props.centerMode) {
-      trackLeft += (100 - slideWidth * trackWidth / 100) / 2;
+      trackLeft += (100 - (slideWidth * trackWidth) / 100) / 2;
     }
     let trackStyle = {
       width: trackWidth + "%",
@@ -716,6 +716,10 @@ export class InnerSlider extends React.Component {
 
     if (this.props.unslick) {
       listProps = { className: "slick-list" };
+      if (this.props.vertical) {
+        /* Reset Vertical Carousel height */
+        trackProps.trackStyle = { ...trackProps.trackStyle, height: "auto" };
+      }
       innerSliderProps = { className };
     }
     return (


### PR DESCRIPTION
When there are fewer slides than `slidesToShow` for vertical carousels, the height of the carousel was ridiculously tall. In this case, the height is being set by `Track` (from `trackProps.trackStyle`), which is normally overridden with an inline style of `height` on `.slick-list` (from `listProps.listStyle`).

See example here: https://codesandbox.io/s/woo4k1k557

I believe this is happening because `unslick` is true, so the `listProps.listStyle` gets blown out completely by this line: `listProps = { className: "slick-list" }`.

This PR: 
- Reset the `height` to `auto` in the `Track` component for vertical carousels when `unslick` is true. 
- Add an example of a vertical carousel with more slides than `slidesToShow`. 
- lint: Add a `semicolon` to the end of imports for consistency.

cc @exogen