### PR TITLE
Allow adding responsive prop after initialization

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -24,13 +24,13 @@ export default class Slider extends React.Component {
     this._responsiveMediaHandlers.push({ query, handler });
   }
 
-  // handles responsive breakpoints
-  componentWillMount() {
-    // performance monitoring
-    //if (process.env.NODE_ENV !== 'production') {
-    //const { whyDidYouUpdate } = require('why-did-you-update')
-    //whyDidYouUpdate(React)
-    //}
+  componentDidUpdate(prevProps) {
+    if (this.props.breakpoint !== prevProps.breakpoint) {
+      this.setBreakPoint();
+    }
+  }
+
+  setBreakPoint = () => {
     if (this.props.responsive) {
       let breakpoints = this.props.responsive.map(
         breakpt => breakpt.breakpoint
@@ -51,9 +51,9 @@ export default class Slider extends React.Component {
         }
         // when not using server side rendering
         canUseDOM() &&
-          this.media(bQuery, () => {
-            this.setState({ breakpoint: breakpoint });
-          });
+        this.media(bQuery, () => {
+          this.setState({ breakpoint: breakpoint });
+        });
       });
 
       // Register media query for full screen. Need to support resize from small to large
@@ -61,10 +61,20 @@ export default class Slider extends React.Component {
       let query = json2mq({ minWidth: breakpoints.slice(-1)[0] });
 
       canUseDOM() &&
-        this.media(query, () => {
-          this.setState({ breakpoint: null });
-        });
+      this.media(query, () => {
+        this.setState({ breakpoint: null });
+      });
     }
+  };
+
+  // handles responsive breakpoints
+  componentWillMount() {
+    // performance monitoring
+    //if (process.env.NODE_ENV !== 'production') {
+    //const { whyDidYouUpdate } = require('why-did-you-update')
+    //whyDidYouUpdate(React)
+    //}
+    this.setBreakPoint();
   }
 
   componentWillUnmount() {
@@ -108,7 +118,7 @@ export default class Slider extends React.Component {
         console.warn(
           `slidesToScroll should be equal to 1 in centerMode, you are using ${
             settings.slidesToScroll
-          }`
+            }`
         );
       }
       settings.slidesToScroll = 1;
@@ -119,7 +129,7 @@ export default class Slider extends React.Component {
         console.warn(
           `slidesToShow should be equal to 1 when fade is true, you're using ${
             settings.slidesToShow
-          }`
+            }`
         );
       }
       if (
@@ -129,7 +139,7 @@ export default class Slider extends React.Component {
         console.warn(
           `slidesToScroll should be equal to 1 when fade is true, you're using ${
             settings.slidesToScroll
-          }`
+            }`
         );
       }
       settings.slidesToShow = 1;


### PR DESCRIPTION
Issue
When you want to supply the responsive prop to the slider after it is initialized, you cannot do it because it is only set on `componentDidMount`. 
Desired behavior
`responsive` should be updated if it the `responsive` prop is updated.

How to reproduce problem:

```
export default class Carousel extends Component {

  state = {
    responsive: [],
  };

  componentDidMount = () => {
    if (this.props.showMultipleSlides) {
      this.setState({
        responsive: [
          {
            breakpoint: 1024,
            settings: {
              slidesToShow: 4,
              slidesToScroll: 1,
            },
          },
          {
            breakpoint: screenMqMed,
            settings: {
              slidesToShow: 2,
              slidesToScroll: 2,
              initialSlide: 2,
              arrows: false,
            },
          },
          {
            breakpoint: 480,
            settings: {
              slidesToShow: 1,
              slidesToScroll: 1,
              arrows: false,
            },
          },
        ],
      });
    } else {
      this.setState({
        responsive: [
          {
            breakpoint: 1024,
            settings: {
              slidesToShow: 1,
              slidesToScroll: 1,
              infinite: true,
              arrows: false,
            },
          },
          {
            breakpoint: 768,
            settings: {
              slidesToShow: 1,
              slidesToScroll: 1,
              initialSlide: 1,
              arrows: false,
            },
          },
          {
            breakpoint: 480,
            settings: {
              slidesToShow: 1,
              slidesToScroll: 1,
              arrows: false,
            },
          },
        ],
      });
    }
  };


  render() {
    const {
      dots,
      infinite,
      speed,
      slidesToShow,
      slidesToScroll,
      arrows,
      children,
      autoPlay,
      showArrowsOnHover,
      ...rest
    } = this.props;
    return (
      <div
      >
        <SlickCarousel
          arrows={arrows}
          autoplay={autoPlay}
          responsive={this.state.responsive}
          afterChange={this.handleScroll}
          dots={dots}
          infinite={infinite}
          speed={speed}
          slidesToShow={slidesToShow}
          slidesToScroll={slidesToScroll}
          variableWidth
          pauseOnHover
          pauseOnFocus
          {...rest}
        >
          {children}
        </SlickCarousel>
      </div>
    );
  }
}
```
With the above `responsive` is always set to `null` right now.