### PR TITLE
Fixing issue with asNavFor not detecting all slide changes

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -391,7 +391,7 @@ export class InnerSlider extends React.Component {
     onLazyLoad && slidesToLoad.length > 0 && onLazyLoad(slidesToLoad);
     this.setState(state, () => {
       asNavFor &&
-        asNavFor.innerSlider.state.currentSlide !== currentSlide &&
+        asNavFor.innerSlider.state.currentSlide !== this.state.currentSlide &&
         asNavFor.innerSlider.slideHandler(index);
       if (!nextState) return;
       this.animationEndCallback = setTimeout(() => {


### PR DESCRIPTION
When the slider has the "asNavFor" configuration, the detection of the slide changes from one slider to the next does not always work. It might work always, or in other occassions, only on every other change.

The issue is that the second slider needs to be refreshed when the slide it points to is different to that of the parent slider, after this parent slider has updated.

This should fix https://github.com/akiran/react-slick/issues/1416