### PR TITLE
Use custom data attributes in custom arrows.

### DIFF
--- a/__tests__/arrows.js
+++ b/__tests__/arrows.js
@@ -14,8 +14,8 @@ function CustomArrow(props) {
   return (
     <span
       className="sample"
-      data-currentSlide={props.currentSlide}
-      data-slideCount={props.slideCount}
+      data-currentslide={props.currentSlide}
+      data-slidecount={props.slideCount}
     />
   );
 }

--- a/src/arrows.js
+++ b/src/arrows.js
@@ -32,8 +32,8 @@ export class PrevArrow extends React.PureComponent {
       onClick: prevHandler
     };
     let customProps = {
-      currentSlide: this.props.currentSlide,
-      slideCount: this.props.slideCount
+      "data-currentslide": this.props.currentSlide,
+      "data-slidecount": this.props.slideCount
     };
     let prevArrow;
 
@@ -79,8 +79,8 @@ export class NextArrow extends React.PureComponent {
       onClick: nextHandler
     };
     let customProps = {
-      currentSlide: this.props.currentSlide,
-      slideCount: this.props.slideCount
+      "data-currentslide": this.props.currentSlide,
+      "data-slidecount": this.props.slideCount
     };
     let nextArrow;
 


### PR DESCRIPTION
This PR adjusts the custom props passed to custom next/prev arrows to use custom data attributes.  This prevents warnings like below from being thrown in React 16.

<img width="725" alt="screen shot 2018-11-12 at 11 23 34 am" src="https://user-images.githubusercontent.com/3892771/48365637-11418680-e671-11e8-9ac9-54ad4a39a9b9.png">
