### PR TITLE
Add link to examples  in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ For all available props, go [here](https://react-slick.neostack.com/docs/api/).
 
 For all available methods, go [here](https://react-slick.neostack.com/docs/api#methods)
 
+### Examples
+
+For simple examples covering most of the features, go [here](https://react-slick.neostack.com/docs/example/simple-slider)
+
 ### Development
 
 Want to run demos locally


### PR DESCRIPTION
I had a hard time finding the examples on the docs website earlier today, so I think adding it to the README would increase readability.