### PR TITLE
Allow custom arrow to be React element

### DIFF
--- a/__tests__/arrows.js
+++ b/__tests__/arrows.js
@@ -4,7 +4,7 @@
 
 sinon.stub(console, "error");
 
-import { render, shallow } from "enzyme";
+import { render, mount, shallow } from "enzyme";
 import React from "react";
 import sinon from "sinon";
 
@@ -21,7 +21,7 @@ function CustomArrow(props) {
 }
 
 describe("Previous arrows", () => {
-  it("should render arrow", () => {
+  it("should render button as default", () => {
     const wrapper = shallow(<PrevArrow />);
     expect(wrapper.find("button")).toHaveLength(1);
   });
@@ -29,6 +29,34 @@ describe("Previous arrows", () => {
   it("should not result in errors", () => {
     shallow(<PrevArrow />);
 
+    expect(console.error.called).toBe(false);
+  });
+
+  it("should render functional component custom arrow", () => {
+    const CustomArrow = props => {
+      return (
+        <span className="customArrow" onClick={props.onClick}>
+          Previous
+        </span>
+      );
+    };
+
+    const wrapper = mount(<PrevArrow prevArrow={<CustomArrow />} />);
+
+    expect(wrapper.find("span.customArrow")).toHaveLength(1);
+    expect(console.error.called).toBe(false);
+  });
+
+  it("sould render React element custom arrow", () => {
+    const customHandlingOfPrevClick = () => null;
+
+    const customImageArrow = (
+      <img className="customArrowImage" onClick={customHandlingOfPrevClick} />
+    );
+
+    const wrapper = mount(<PrevArrow prevArrow={customImageArrow} />);
+
+    expect(wrapper.find("img.customArrowImage")).toHaveLength(1);
     expect(console.error.called).toBe(false);
   });
 
@@ -45,16 +73,44 @@ describe("Previous arrows", () => {
 });
 
 describe("Next arrows", () => {
-  it("should render arrow", () => {
+  it("should render button as default", () => {
     const wrapper = shallow(<NextArrow />);
     expect(wrapper.find("button")).toHaveLength(1);
   });
 
-  // it('should not result in errors', () => {
-  //   shallow(<NextArrow />);
-  //
-  //   expect(console.error.called).toBe(false);
-  // });
+  it("should not result in errors", () => {
+    shallow(<NextArrow />);
+
+    expect(console.error.called).toBe(false);
+  });
+
+  it("should render functional component custom arrow", () => {
+    const CustomArrow = props => {
+      return (
+        <span className="customArrow" onClick={props.onClick}>
+          Next
+        </span>
+      );
+    };
+
+    const wrapper = mount(<NextArrow nextArrow={<CustomArrow />} />);
+
+    expect(wrapper.find("span.customArrow")).toHaveLength(1);
+    expect(console.error.called).toBe(false);
+  });
+
+  it("sould render React element custom arrow", () => {
+    const customHandlingOfNextClick = () => null;
+
+    const customImageArrow = (
+      <img className="customArrowImage" onClick={customHandlingOfNextClick} />
+    );
+
+    const wrapper = mount(<NextArrow nextArrow={customImageArrow} />);
+
+    expect(wrapper.find("img.customArrowImage")).toHaveLength(1);
+    expect(console.error.called).toBe(false);
+  });
 
   // it('should pass slide data to custom arrow', () => {
   //   let elAttributes;

--- a/src/arrows.js
+++ b/src/arrows.js
@@ -31,19 +31,9 @@ export class PrevArrow extends React.PureComponent {
       style: { display: "block" },
       onClick: prevHandler
     };
-    let customProps = {
-      currentSlide: this.props.currentSlide,
-      slideCount: this.props.slideCount
-    };
-    let prevArrow;
 
-    if (this.props.prevArrow) {
-      prevArrow = React.cloneElement(this.props.prevArrow, {
-        ...prevArrowProps,
-        ...customProps
-      });
-    } else {
-      prevArrow = (
+    if (!this.props.prevArrow) {
+      return (
         <button key="0" type="button" {...prevArrowProps}>
           {" "}
           Previous
@@ -51,7 +41,24 @@ export class PrevArrow extends React.PureComponent {
       );
     }
 
-    return prevArrow;
+    let isReactElement = typeof this.props.prevArrow.type === "string";
+
+    if (isReactElement) {
+      return React.cloneElement(this.props.prevArrow, {
+        ...prevArrowProps,
+        ...this.props.prevArrow.props
+      });
+    }
+
+    let customProps = {
+      currentSlide: this.props.currentSlide,
+      slideCount: this.props.slideCount
+    };
+
+    return React.cloneElement(this.props.prevArrow, {
+      ...prevArrowProps,
+      ...customProps
+    });
   }
 }
 
@@ -78,26 +85,33 @@ export class NextArrow extends React.PureComponent {
       style: { display: "block" },
       onClick: nextHandler
     };
-    let customProps = {
-      currentSlide: this.props.currentSlide,
-      slideCount: this.props.slideCount
-    };
-    let nextArrow;
 
-    if (this.props.nextArrow) {
-      nextArrow = React.cloneElement(this.props.nextArrow, {
-        ...nextArrowProps,
-        ...customProps
-      });
-    } else {
-      nextArrow = (
-        <button key="1" type="button" {...nextArrowProps}>
+    if (!this.props.nextArrow) {
+      return (
+        <button key="0" type="button" {...nextArrowProps}>
           {" "}
           Next
         </button>
       );
     }
 
-    return nextArrow;
+    let isReactElement = typeof this.props.nextArrow.type === "string";
+
+    if (isReactElement) {
+      return React.cloneElement(this.props.nextArrow, {
+        ...nextArrowProps,
+        ...this.props.nextArrow.props
+      });
+    }
+
+    let customProps = {
+      currentSlide: this.props.currentSlide,
+      slideCount: this.props.slideCount
+    };
+
+    return React.cloneElement(this.props.nextArrow, {
+      ...nextArrowProps,
+      ...customProps
+    });
   }
 }


### PR DESCRIPTION
Former to this commit using a React element directly as an prev or next arrow resulted in React errors due to props unknown to the React elements they were applied to.
The common props (like className and onClick) are still attached to the cloned React element, but won't be overwritten, if they are already defined.

Given the amount of people trying to use simple React elements as custom arrows shows the need for this fix. This PR will solve the following issues (which were mostly just closed without a real solution):

- #623
- #728
- #780
- #1130
- #1195
- #1238
- #1331