### PR TITLE
fix surplus closure

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -302,15 +302,12 @@ export class InnerSlider extends React.Component {
     Array.prototype.forEach.call(images, image => {
       const handler = () =>
         ++loadedCount && loadedCount >= imagesCount && this.onWindowResized();
-      if (!image.onclick) {
-        image.onclick = () => image.parentNode.focus();
-      } else {
-        const prevClickHandler = image.onclick;
-        image.onclick = () => {
-          prevClickHandler();
+        image.addEventListener("click", function () {
+          if(document.activeElement == image.parentNode){
+            return;
+          }
           image.parentNode.focus();
-        };
-      }
+        }, false)
       if (!image.onload) {
         if (this.props.lazyLoad) {
           image.onload = () => {


### PR DESCRIPTION
Variable prevClickHandler can't be released because of closure. And function checkImagesLoad will execute at least 8 times each movement in autoplay mode. In my project, it will add 200kb usage of memory in website each movement and my project is used in webview on iOS platform.  After monitoring usage of memory in iPhone，we found 200kb usage of memory in website can cause 2M usage of memory in webview in iPhone.  And it will cause crash of webview after moving some times.
