### PR TITLE
Fix a bug that `settings: "unslick"` renders nothing #1172

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -203,7 +203,7 @@ export default class Slider extends React.Component {
 
     if (settings === "unslick") {
       const className = "regular slider " + (this.props.className || "");
-      return <div className={className}>{newChildren}</div>;
+      return <div className={className}>{children}</div>;
     } else if (newChildren.length <= settings.slidesToShow) {
       settings.unslick = true;
     }


### PR DESCRIPTION
In case of `settings: "unslick"`, newChildren will be empty list. because of these lines:
https://github.com/akiran/react-slick/blob/48c93ed36cfb58991e6bf4d34a1a588094281d12/src/slider.js#L94-L97
https://github.com/akiran/react-slick/blob/48c93ed36cfb58991e6bf4d34a1a588094281d12/src/slider.js#L163-L167 

So make slider returns natural `children`, instead of `newChildren`

p.s. As i commented on https://github.com/akiran/react-slick/issues/1172#issuecomment-445483592, https://github.com/akiran/react-slick/commit/b85f15672548a78cd1407331b068615711edd98f#diff-e8eaa42a1b8ab4981d9272be425c03dfL121 may broke this function. 

