### PR TITLE
Renamed childNodes

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -723,7 +723,7 @@ export const getTrackLeft = spec => {
     var targetSlideIndex;
     let trackElem = ReactDOM.findDOMNode(trackRef);
     targetSlideIndex = slideIndex + getPreClones(spec);
-    targetSlide = trackElem && trackElem.childNodes[targetSlideIndex];
+    targetSlide = trackElem && trackElem.children[targetSlideIndex];
     targetLeft = targetSlide ? targetSlide.offsetLeft * -1 : 0;
     if (centerMode === true) {
       targetSlideIndex = infinite


### PR DESCRIPTION
For some reason, the following errors were happening upon mounting the Slider component using Jest & Enzyme: 

![screenshot 2019-01-22 at 10 29 36](https://user-images.githubusercontent.com/8352927/51527861-b036eb80-1e35-11e9-93dd-6e7adfd6d544.png)
![screenshot 2019-01-22 at 10 29 50](https://user-images.githubusercontent.com/8352927/51527862-b036eb80-1e35-11e9-8c71-2e8ea4e3431a.png)
![screenshot 2019-01-22 at 10 30 04](https://user-images.githubusercontent.com/8352927/51527863-b0cf8200-1e35-11e9-9962-1fcd5c97ffb5.png)

This PR should fix the following errors detected upon mounting Slider component by using jest & Enzyme.
