### PR TITLE
Change the Checking can go next when centerMode

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -76,17 +76,18 @@ export const getSwipeDirection = (touchObject, verticalSwiping = false) => {
 export const canGoNext = spec => {
   let canGo = true;
   if (!spec.infinite) {
-    if (spec.centerMode && spec.currentSlide >= spec.slideCount - 1) {
-      canGo = false;
-    } else if (
-      spec.slideCount <= spec.slidesToShow ||
-      spec.currentSlide >= spec.slideCount - spec.slidesToShow
-    ) {
-      canGo = false;
+    if (spec.centerMode) {
+      if (spec.currentSlide >= spec.slideCount - 1) {
+        canGo = false;
+      } else if (spec.slideCount <= spec.slidesToShow || spec.currentSlide >= spec.slideCount - spec.slidesToShow / 2) {
+        canGo = false;
+      }
+    } else if (spec.slideCount <= spec.slidesToShow || spec.currentSlide >= spec.slideCount - spec.slidesToShow) {
+        canGo = false;
     }
   }
   return canGo;
-};
+ };
 
 // given an object and a list of keys, return new object with given keys
 export const extractObject = (spec, keys) => {


### PR DESCRIPTION
When Checking we can go next or not, when center mode
previous version if current Slide is larger then slide count - slide to show can' go next
for this reason, We can't see the last few images
In center mode not slideToShow, we need to check slideToShow / 2