### PR TITLE
Persist custom arrow className

### DIFF
--- a/src/arrows.js
+++ b/src/arrows.js
@@ -40,7 +40,8 @@ export class PrevArrow extends React.PureComponent {
     if (this.props.prevArrow) {
       prevArrow = React.cloneElement(this.props.prevArrow, {
         ...prevArrowProps,
-        ...customProps
+        ...customProps,
+        className: classnames(prevArrowProps.className, this.props.prevArrow.className)
       });
     } else {
       prevArrow = (
@@ -87,7 +88,8 @@ export class NextArrow extends React.PureComponent {
     if (this.props.nextArrow) {
       nextArrow = React.cloneElement(this.props.nextArrow, {
         ...nextArrowProps,
-        ...customProps
+        ...customProps,
+        className: classnames(nextArrowProps.className, this.props.nextArrow.className)
       });
     } else {
       nextArrow = (


### PR DESCRIPTION
Hello 👋 

I noticed in my project that the class I have on my arrow component disappears when trying to use custom components (I'm using css modules)
```js
const settings = {
 nextArrow: (
    <div className={styles.arrowContainer}>
        <ArrowRight className={styles.arrow} />
    </div>
  )
}
```
I would like to remove the `::before` styling on `.slick-prev` and `.slick-next` (from [slick-carousel](https://github.com/kenwheeler/slick/blob/master/slick/slick-theme.css#L89)), but I can't 😔

So, I opened this PR in hopes to fix that. Other than that, thanks for this amazing library!

Parth