### PR TITLE
lazy loading for the closest slides images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/akiran/react-slick/tree/HEAD)
 
+- added option to enable lazy loading for the closest slides images (for previous and next slide images)
+
 ## 0.22.0
 
 **Release Changes**

--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -20,6 +20,7 @@ import Rtl from '../examples/Rtl'
 import VariableWidth from '../examples/VariableWidth'
 import AdaptiveHeight from '../examples/AdaptiveHeight'
 import LazyLoad from '../examples/LazyLoad'
+import LazyLoadClosestImages from '../examples/LazyLoadClosestImages'
 import Fade from '../examples/Fade'
 import SlickGoTo from '../examples/SlickGoTo'
 import CustomArrows from '../examples/CustomArrows'
@@ -53,6 +54,7 @@ export default class App extends React.Component {
         <VariableWidth />
         <AdaptiveHeight />
         <LazyLoad />
+        <LazyLoadClosestImages />
         <Fade />
         <SlideChangeHooks />
         <SlickGoTo />

--- a/examples/LazyLoadClosestImages.js
+++ b/examples/LazyLoadClosestImages.js
@@ -1,0 +1,48 @@
+import React, { Component } from "react";
+import Slider from "../src/slider";
+import { baseUrl } from "./config";
+
+export default class LazyLoadClosestImages extends Component {
+  render() {
+    const settings = {
+      dots: true,
+      lazyLoad: 1,
+      infinite: true,
+      speed: 500,
+      slidesToShow: 1,
+      slidesToScroll: 1,
+      initialSlide: 1
+    };
+    return (
+      <div>
+        <h2> Lazy Load previous and next slide images</h2>
+        <Slider {...settings}>
+          <div>
+            <img src={baseUrl + "/abstract01.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract02.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract03.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract04.jpg"} />
+          </div>
+          <div>
+            <img src="https://picsum.photos/400/300?image=0" />
+          </div>
+          <div>
+            <img src="https://picsum.photos/400/300?image=1" />
+          </div>
+          <div>
+            <img src="https://picsum.photos/400/300?image=2" />
+          </div>
+          <div>
+            <img src="https://picsum.photos/400/300?image=3" />
+          </div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -25,9 +25,18 @@ export const getRequiredLazySlides = spec => {
 };
 
 // startIndex that needs to be present
-export const lazyStartIndex = spec =>
-  spec.currentSlide - lazySlidesOnLeft(spec);
-export const lazyEndIndex = spec => spec.currentSlide + lazySlidesOnRight(spec);
+export const lazyStartIndex = spec => {
+  const { lazyLoad } = spec;
+  const lazyLoadSlides = typeof lazyLoad === "number" ? lazyLoad : 0;
+  return spec.currentSlide - lazySlidesOnLeft(spec) - lazyLoadSlides;
+};
+
+export const lazyEndIndex = spec => {
+  const { lazyLoad } = spec;
+  const lazyLoadSlides = typeof lazyLoad === "number" ? lazyLoad : 0;
+  return spec.currentSlide + lazySlidesOnRight(spec) + lazyLoadSlides;
+};
+
 export const lazySlidesOnLeft = spec =>
   spec.centerMode
     ? Math.floor(spec.slidesToShow / 2) +

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -27,13 +27,15 @@ export const getRequiredLazySlides = spec => {
 // startIndex that needs to be present
 export const lazyStartIndex = spec => {
   const { lazyLoad } = spec;
-  const lazyLoadSlides = typeof lazyLoad === "number" ? lazyLoad : 0;
+  // update the index if lazyload is positive integer
+  const lazyLoadSlides = /^\d+$/.test(lazyLoad) ? parseInt(lazyLoad, 10) : 0;
   return spec.currentSlide - lazySlidesOnLeft(spec) - lazyLoadSlides;
 };
 
 export const lazyEndIndex = spec => {
   const { lazyLoad } = spec;
-  const lazyLoadSlides = typeof lazyLoad === "number" ? lazyLoad : 0;
+  // update the index if lazyload is positive integer
+  const lazyLoadSlides = /^\d+$/.test(lazyLoad) ? parseInt(lazyLoad, 10) : 0;
   return spec.currentSlide + lazySlidesOnRight(spec) + lazyLoadSlides;
 };
 


### PR DESCRIPTION
Hello! 

I am using `react-slick` for our image sliders on the search page. Since there are 20 sliders and we use `lazyload: true`, it gave a white flash when you click next/prev ( a right to left transition to an empty rectangle before the next image loads) 

So I just created this PR to add option to enable lazy load with preloading the closest slides images (for previous and next slide images). Since the `lazyload` prop already takes string `progressive`, I overload it by passing a number (the number of images you would like to preload). Ideally it could take an object to config.

Could you please review and let me know your thought?

Thanks!