### PR TITLE
Lazyload closest images using array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Release Changes**
 
 - Internal Changes
+  - added option to enable lazy loading for the closest slides images (for previous and next slide images)
   - converted InnerSlider from createReactClass object to ES6 class
   - removed all the mixins, created classMethods and pure utility functions instead
   - changed autoplay from setTimeout to setInterval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Change Log
 
 ## [Unreleased](https://github.com/akiran/react-slick/tree/HEAD)
+- Note
+  - Project forked by Domain at this point to maintain this codebase.
+
+- Added 
+  - option to enable lazy loading for the closest slides images (for previous and next slide images) See example `LazyLoadClosestImages`
 
 ## 0.22.0
 
 **Release Changes**
 
 - Internal Changes
-  - added option to enable lazy loading for the closest slides images (for previous and next slide images)
   - converted InnerSlider from createReactClass object to ES6 class
   - removed all the mixins, created classMethods and pure utility functions instead
   - changed autoplay from setTimeout to setInterval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Change Log
 
 ## [Unreleased](https://github.com/akiran/react-slick/tree/HEAD)
-- Note
-  - Project forked by Domain at this point to maintain this codebase.
-
 - Added 
   - option to enable lazy loading for the closest slides images (for previous and next slide images) See example `LazyLoadClosestImages`
 

--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -20,6 +20,7 @@ import Rtl from '../examples/Rtl'
 import VariableWidth from '../examples/VariableWidth'
 import AdaptiveHeight from '../examples/AdaptiveHeight'
 import LazyLoad from '../examples/LazyLoad'
+import LazyLoadClosestImages from '../examples/LazyLoadClosestImages'
 import Fade from '../examples/Fade'
 import SlickGoTo from '../examples/SlickGoTo'
 import CustomArrows from '../examples/CustomArrows'
@@ -53,6 +54,7 @@ export default class App extends React.Component {
         <VariableWidth />
         <AdaptiveHeight />
         <LazyLoad />
+        <LazyLoadClosestImages />
         <Fade />
         <SlideChangeHooks />
         <SlickGoTo />

--- a/examples/LazyLoadClosestImages.js
+++ b/examples/LazyLoadClosestImages.js
@@ -6,7 +6,7 @@ export default class LazyLoadClosestImages extends Component {
     render() {
         const settings = {
             dots: true,
-            lazyLoad: [0, 1],
+            lazyLoad: [0, 1],  // preload 0 images before the current image, preload 1 image after the current image
             infinite: true,
             speed: 500,
             slidesToShow: 1,

--- a/examples/LazyLoadClosestImages.js
+++ b/examples/LazyLoadClosestImages.js
@@ -1,0 +1,47 @@
+import React, { Component } from "react";
+import Slider from "../src/slider";
+import { baseUrl } from "./config";
+
+export default class LazyLoadClosestImages extends Component {
+    render() {
+        const settings = {
+            dots: true,
+            lazyLoad: [0, 1],
+            infinite: true,
+            speed: 500,
+            slidesToShow: 1,
+            slidesToScroll: 1,
+        };
+        return (
+            <div>
+                <h2> Lazy Load previous and next slide images</h2>
+                <Slider {...settings}>
+                    <div>
+                        <img src={baseUrl + "/abstract01.jpg"} />
+                    </div>
+                    <div>
+                        <img src={baseUrl + "/abstract02.jpg"} />
+                    </div>
+                    <div>
+                        <img src={baseUrl + "/abstract03.jpg"} />
+                    </div>
+                    <div>
+                        <img src={baseUrl + "/abstract04.jpg"} />
+                    </div>
+                    <div>
+                        <img src="https://picsum.photos/400/300?image=0" />
+                    </div>
+                    <div>
+                        <img src="https://picsum.photos/400/300?image=1" />
+                    </div>
+                    <div>
+                        <img src="https://picsum.photos/400/300?image=2" />
+                    </div>
+                    <div>
+                        <img src="https://picsum.photos/400/300?image=3" />
+                    </div>
+                </Slider>
+            </div>
+        );
+    }
+}

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -24,10 +24,20 @@ export const getRequiredLazySlides = spec => {
   return requiredSlides;
 };
 
+const getPreloadNumber = (lazyLoad) => {
+  const [preloadBefore = 0, preloadAfter = 0] = Array.isArray(lazyLoad) ? lazyLoad : [0, 0];
+  return {
+    preloadBefore: parseInt(preloadBefore, 10),
+    preloadAfter: parseInt(preloadAfter, 10)
+  }
+}
+
 // startIndex that needs to be present
 export const lazyStartIndex = spec =>
-  spec.currentSlide - lazySlidesOnLeft(spec);
-export const lazyEndIndex = spec => spec.currentSlide + lazySlidesOnRight(spec);
+  spec.currentSlide - lazySlidesOnLeft(spec) - getPreloadNumber(spec.lazyLoad).preloadBefore;
+export const lazyEndIndex = spec =>
+  spec.currentSlide + lazySlidesOnRight(spec) + getPreloadNumber(spec.lazyLoad).preloadAfter;
+
 export const lazySlidesOnLeft = spec =>
   spec.centerMode
     ? Math.floor(spec.slidesToShow / 2) +


### PR DESCRIPTION
Hello there!

I am using react-slick for our image sliders on the search page. Since there are 20 sliders and we use lazyload: true, it gave a white flash when you click next/prev ( a right to left transition to an empty rectangle before the next image loads)

So I just created this PR to add option to enable lazy load with preloading the closest slides images (for previous and next slide images). Since the lazyload prop already takes string progressive, I overload it by passing an array with two integers, first one is number of items you would like to preload before current image, and second one is after the current image. Ideally it could take an object to config.

Could you please review and let me know your thought?

Thanks!