### PR TITLE
Fixed vw size available in centerPadding prop

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -103,10 +103,12 @@ export const initializedState = spec => {
   let trackWidth = Math.ceil(getWidth(ReactDOM.findDOMNode(spec.trackRef)));
   let slideWidth;
   if (!spec.vertical) {
-    let centerPaddingAdj = spec.centerMode && parseInt(spec.centerPadding) * 2;
+    let centerPaddingAdj =
+      spec.centerMode && parseFloat(spec.centerPadding) * 2;
     if (
       typeof spec.centerPadding === "string" &&
-      spec.centerPadding.slice(-1) === "%"
+      (spec.centerPadding.slice(-1) === "%" ||
+        spec.centerPadding.slice(-2) === "vw")
     ) {
       centerPaddingAdj *= listWidth / 100;
     }


### PR DESCRIPTION
I'm using react-slick on the mobile web and the images has to fit center on the screen.
so I've set a `true` on `centerPadding` prop. but there've been some problems.

1. `vw` is not supported (ex 10vw)
2. and float size is not supported (ex. 4.5vw)

so I fixed it.
I've tested on my mobile and then there was nothing wrong.