### PR TITLE
LazyLoad preloading next/previous slides by configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ For all available props, go [here](https://react-slick.neostack.com/docs/api/).
 
 For all available methods, go [here](https://react-slick.neostack.com/docs/api#methods)
 
+### Examples
+
+For simple examples covering most of the features, go [here](https://react-slick.neostack.com/docs/example/simple-slider)
+
 ### Development
 
 Want to run demos locally

--- a/examples/LazyLoad.js
+++ b/examples/LazyLoad.js
@@ -6,7 +6,8 @@ export default class LazyLoad extends Component {
   render() {
     const settings = {
       dots: true,
-      lazyLoad: true,
+      lazyLoad: "offset",
+      lazyLoadOffset: 1,
       infinite: true,
       speed: 500,
       slidesToShow: 1,

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node-sass": "^4.5.2",
     "opn": "^5.4.0",
     "postcss-loader": "^1.3.3",
-    "prettier": "^1.14.3",    
+    "prettier": "^1.14.3",
     "raf": "^3.4.0",
     "react": "^16.0.0",
     "react-addons-test-utils": "^15.6.2",

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -188,6 +188,7 @@ export class InnerSlider extends React.Component {
     //   this.props.onLazyLoad([leftMostSlide])
     // }
     this.adaptHeight();
+    this.offsetLazyLoad();
   };
   onWindowResized = setTrackStyle => {
     if (this.debouncedResize) this.debouncedResize.cancel();
@@ -276,15 +277,15 @@ export class InnerSlider extends React.Component {
     let childrenCount = React.Children.count(this.props.children);
     const spec = { ...this.props, ...this.state, slideCount: childrenCount };
     let slideCount = getPreClones(spec) + getPostClones(spec) + childrenCount;
-    let trackWidth = 100 / this.props.slidesToShow * slideCount;
+    let trackWidth = (100 / this.props.slidesToShow) * slideCount;
     let slideWidth = 100 / slideCount;
     let trackLeft =
-      -slideWidth *
-      (getPreClones(spec) + this.state.currentSlide) *
-      trackWidth /
+      (-slideWidth *
+        (getPreClones(spec) + this.state.currentSlide) *
+        trackWidth) /
       100;
     if (this.props.centerMode) {
-      trackLeft += (100 - slideWidth * trackWidth / 100) / 2;
+      trackLeft += (100 - (slideWidth * trackWidth) / 100) / 2;
     }
     let trackStyle = {
       width: trackWidth + "%",
@@ -328,6 +329,35 @@ export class InnerSlider extends React.Component {
         }
       }
     });
+  };
+  offsetLazyLoad = () => {
+    const lazyLoadOffset = this.props.lazyLoadOffset;
+    let slidesToLoad = [];
+    for (
+      let index = this.state.currentSlide - 1;
+      index >= this.state.currentSlide - lazyLoadOffset;
+      index--
+    ) {
+      slidesToLoad.push(index);
+    }
+
+    for (
+      let index = this.state.currentSlide + 1;
+      index <= this.state.currentSlide + lazyLoadOffset;
+      index++
+    ) {
+      slidesToLoad.push(index);
+    }
+
+    slidesToLoad = slidesToLoad.filter(
+      index => index >= 0 && !this.state.lazyLoadedList.includes(index)
+    );
+
+    if (slidesToLoad.length > 0) {
+      this.setState(state => ({
+        lazyLoadedList: state.lazyLoadedList.concat(slidesToLoad)
+      }));
+    }
   };
   progressiveLazyLoad = () => {
     let slidesToLoad = [];

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -353,7 +353,7 @@ export const swipeMove = (e, spec) => {
   let verticalSwipeLength = Math.round(
     Math.sqrt(Math.pow(touchObject.curY - touchObject.startY, 2))
   );
-  if (!verticalSwiping && !swiping && verticalSwipeLength > 10) {
+  if (!verticalSwiping && !swiping && verticalSwipeLength > 10 && touchObject.swipeLength <= 10) {
     return { scrolling: true };
   }
   if (verticalSwiping) touchObject.swipeLength = verticalSwipeLength;


### PR DESCRIPTION
Now LazyLoad is available with preloading next/prev slides as configured.

All you have to do is set the following props:
```
      lazyLoad: "offset",
      lazyLoadOffset: 1,
```

lazyLoadOffset will configure the number of next/prev slides to preload.