### PR TITLE
Check spec.slideWidth is null

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -54,7 +54,7 @@ var getSlideStyle = function(spec) {
     style.position = "relative";
     if (spec.vertical) {
       style.top = -spec.index * parseInt(spec.slideHeight);
-    } else {
+    } else if (spec.slideWidth) {
       style.left = -spec.index * parseInt(spec.slideWidth);
     }
     style.opacity = spec.currentSlide === spec.index ? 1 : 0;


### PR DESCRIPTION
When using `fade, variableWidth, infinite: false` options, this warning will bothering you.
```
Warning: `NaN` is an invalid value for the `left` css style property.
```
because `spec.slideWidth` is `null` on initialized.

This should fix #1351 