### PR TITLE
Add a null handler for breakpoint changes in responsive setting

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -68,7 +68,7 @@ export default class Slider extends React.Component {
   }
 
   componentWillUnmount() {
-    this._responsiveMediaHandlers.forEach(function(obj) {
+    this._responsiveMediaHandlers.forEach(function (obj) {
       enquire.unregister(obj.query, obj.handler);
     });
   }
@@ -91,10 +91,14 @@ export default class Slider extends React.Component {
       newProps = this.props.responsive.filter(
         resp => resp.breakpoint === this.state.breakpoint
       );
-      settings =
+      const isNewProp = newProps.length > 0
+      settings = { ...defaultProps, ...this.props };
+      if (isNewProp) {
+        settings =
         newProps[0].settings === "unslick"
           ? "unslick"
-          : { ...defaultProps, ...this.props, ...newProps[0].settings };
+          : { ...settings, ...newProps[0].settings };
+      }
     } else {
       settings = { ...defaultProps, ...this.props };
     }
@@ -107,7 +111,7 @@ export default class Slider extends React.Component {
       ) {
         console.warn(
           `slidesToScroll should be equal to 1 in centerMode, you are using ${
-            settings.slidesToScroll
+          settings.slidesToScroll
           }`
         );
       }
@@ -118,7 +122,7 @@ export default class Slider extends React.Component {
       if (settings.slidesToShow > 1 && process.env.NODE_ENV !== "production") {
         console.warn(
           `slidesToShow should be equal to 1 when fade is true, you're using ${
-            settings.slidesToShow
+          settings.slidesToShow
           }`
         );
       }
@@ -128,7 +132,7 @@ export default class Slider extends React.Component {
       ) {
         console.warn(
           `slidesToScroll should be equal to 1 when fade is true, you're using ${
-            settings.slidesToScroll
+          settings.slidesToScroll
           }`
         );
       }


### PR DESCRIPTION
I am not sure if this is a viable change to be added in master.. i came across an edge case where I am sending responsive prop to the react-slick slider component but the current state.responsive value is not present in my supplied array. 
In that case the page crashes. 
I have added a null handler. If, post filter of the props.responsive array against state.responsive returns a blank array, the final settings is set as if there was no responsive array in the props.
Please carefully review the change. 
If this is merged asap, i would be grateful, i have a breaking change in my react application which is live