### PR TITLE
Prevent slide change when beforeChange return false

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -384,7 +384,12 @@ export class InnerSlider extends React.Component {
       useCSS: this.props.useCSS && !dontAnimate
     });
     if (!state) return;
-    beforeChange && beforeChange(currentSlide, state.currentSlide);
+    if (beforeChange) {
+      if (beforeChange(currentSlide, state.currentSlide) === false) {
+        // prevent slide change when beforeChange return false
+        return;
+      }
+    }
     let slidesToLoad = state.lazyLoadedList.filter(
       value => this.state.lazyLoadedList.indexOf(value) < 0
     );


### PR DESCRIPTION
Useful for custom behaviors : 
- #1221 : Prevent user from advancing slide until condition is met
- ignoring some slide when "inactive"

Example :
```javascript
beforeChange(oldIndex, newIndex) {
   if (newIndex === 5) {
     this.slider.slickGoTo(6);
     return false;
   }
 }
```