### PR TITLE
Add slide offset value to swipeEvent callback

### DIFF
--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -28,6 +28,7 @@ import DynamicSlides  from '../examples/DynamicSlides'
 import VerticalMode  from '../examples/VerticalMode'
 import SwipeToSlide from '../examples/SwipeToSlide'
 import VerticalSwipeToSlide from '../examples/VerticalSwipeToSlide'
+import SwipeAnimated from '../examples/SwipeAnimated'
 import CustomPaging from '../examples/CustomPaging'
 import CustomSlides from '../examples/CustomSlides'
 import AsNavFor from '../examples/AsNavFor'
@@ -64,6 +65,7 @@ export default class App extends React.Component {
         <VerticalMode />
         <SwipeToSlide />
         <VerticalSwipeToSlide />
+        <SwipeAnimated />
         <AsNavFor />
         <AppendDots />
       </div>

--- a/examples/SwipeAnimated.js
+++ b/examples/SwipeAnimated.js
@@ -1,0 +1,48 @@
+import React, { Component } from "react";
+import Slider from "../src/slider";
+
+export default class SwipeAnimated extends Component {
+  state = {
+    currentIndex: 0,
+    tempIndexOffset: 0
+  };
+
+  beforeChange = (oldIndex, newIndex) => {
+    this.setState({ currentIndex: newIndex, tempIndexOffset: 0 });
+  };
+
+  swipeEvent = (swipeDirection, slideOffset) => {
+    if (slideOffset && slideOffset !== this.state.tempIndexOffset) {
+      this.setState({ tempIndexOffset: slideOffset });
+    }
+  };
+
+  render() {
+    const settings = {
+      className: "center",
+      infinite: true,
+      centerMode: true,
+      slidesToShow: 5,
+      swipeToSlide: true,
+      beforeChange: this.beforeChange,
+      swipeEvent: this.swipeEvent
+    };
+
+    const currentIndex = this.state.currentIndex + this.state.tempIndexOffset;
+
+    return (
+      <div>
+        <h2>Swipe Animated</h2>
+        <Slider {...settings}>
+          {Array.from({ length: 9 }).map((x, i) => (
+            <div>
+              <h3 style={currentIndex === i ? { color: "red" } : undefined}>
+                {i + 1}
+              </h3>
+            </div>
+          ))}
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -48,7 +48,7 @@ export const getSwipeDirection = (touchObject, verticalSwiping = false) => {
   xDist = touchObject.startX - touchObject.curX;
   yDist = touchObject.startY - touchObject.curY;
   r = Math.atan2(yDist, xDist);
-  swipeAngle = Math.round(r * 180 / Math.PI);
+  swipeAngle = Math.round((r * 180) / Math.PI);
   if (swipeAngle < 0) {
     swipeAngle = 360 - Math.abs(swipeAngle);
   }
@@ -195,7 +195,7 @@ export const slideHandler = spec => {
       finalSlide = animationSlide + slideCount;
       if (!infinite) finalSlide = 0;
       else if (slideCount % slidesToScroll !== 0)
-        finalSlide = slideCount - slideCount % slidesToScroll;
+        finalSlide = slideCount - (slideCount % slidesToScroll);
     } else if (!canGoNext(spec) && animationSlide > currentSlide) {
       animationSlide = finalSlide = currentSlide;
     } else if (centerMode && animationSlide >= slideCount) {
@@ -265,7 +265,8 @@ export const changeSlide = (spec, options) => {
     slideOffset = indexOffset === 0 ? slidesToScroll : indexOffset;
     targetSlide = currentSlide + slideOffset;
     if (lazyLoad && !infinite) {
-      targetSlide = (currentSlide + slidesToScroll) % slideCount + indexOffset;
+      targetSlide =
+        ((currentSlide + slidesToScroll) % slideCount) + indexOffset;
     }
   } else if (options.message === "dots") {
     // Click on dots
@@ -379,8 +380,12 @@ export const swipeMove = (e, spec) => {
     }
   }
   if (!swiped && swipeEvent) {
-    swipeEvent(swipeDirection);
+    swipeEvent(swipeDirection, 0);
     state["swiped"] = true;
+  } else if (swipeEvent) {
+    var slideOffset = -positionOffset * getSlideCount(spec);
+    swipeEvent(swipeDirection, slideOffset);
+    state["slideOffset"] = slideOffset;
   }
   if (!vertical) {
     if (!rtl) {
@@ -704,7 +709,7 @@ export const getTrackLeft = spec => {
       slideCount % slidesToScroll !== 0 &&
       slideIndex + slidesToScroll > slideCount
     ) {
-      slidesToOffset = slidesToShow - slideCount % slidesToScroll;
+      slidesToOffset = slidesToShow - (slideCount % slidesToScroll);
     }
     if (centerMode) {
       slidesToOffset = parseInt(slidesToShow / 2);


### PR DESCRIPTION
I pass a `slideOffset` value to the swipeEvent callback. The value is the difference between the previous selected slide and the slide that, due to a swipe, currently appears as the current slide.

```
swipeEvent = ( swipeDirection, slideOffset ) => {
    console.log("Direction  "+swipeDirection+" with offset "+slideOffset);
    // Direction right with offset -2
}
```

This allows to animate a slide during a swipe. The swipe is a translate of the whole carousel, so the current slide is not updated until the swipe is over.

I've also created an example, see [/examples/SwipeAnimated.js](https://github.com/scailbc/react-slick/blob/13c38c80fea70e64a7ef10470aab011fb32cebb8/examples/SwipeAnimated.js)