### PR TITLE
Memoize style objects, so that Slider children can be pure components

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -4,7 +4,7 @@ import React from "react";
 import { InnerSlider } from "./inner-slider";
 import json2mq from "json2mq";
 import defaultProps from "./default-props";
-import { canUseDOM } from "./utils/innerSliderUtils";
+import { canUseDOM, getChildrenStyle } from "./utils/innerSliderUtils";
 const enquire = canUseDOM() && require("enquire.js");
 
 export default class Slider extends React.Component {
@@ -181,10 +181,7 @@ export default class Slider extends React.Component {
             React.cloneElement(children[k], {
               key: 100 * i + 10 * j + k,
               tabIndex: -1,
-              style: {
-                width: `${100 / settings.slidesPerRow}%`,
-                display: "inline-block"
-              }
+              style: getChildrenStyle(settings.slidesPerRow)
             })
           );
         }

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -48,7 +48,7 @@ export const getSwipeDirection = (touchObject, verticalSwiping = false) => {
   xDist = touchObject.startX - touchObject.curX;
   yDist = touchObject.startY - touchObject.curY;
   r = Math.atan2(yDist, xDist);
-  swipeAngle = Math.round(r * 180 / Math.PI);
+  swipeAngle = Math.round((r * 180) / Math.PI);
   if (swipeAngle < 0) {
     swipeAngle = 360 - Math.abs(swipeAngle);
   }
@@ -195,7 +195,7 @@ export const slideHandler = spec => {
       finalSlide = animationSlide + slideCount;
       if (!infinite) finalSlide = 0;
       else if (slideCount % slidesToScroll !== 0)
-        finalSlide = slideCount - slideCount % slidesToScroll;
+        finalSlide = slideCount - (slideCount % slidesToScroll);
     } else if (!canGoNext(spec) && animationSlide > currentSlide) {
       animationSlide = finalSlide = currentSlide;
     } else if (centerMode && animationSlide >= slideCount) {
@@ -265,7 +265,8 @@ export const changeSlide = (spec, options) => {
     slideOffset = indexOffset === 0 ? slidesToScroll : indexOffset;
     targetSlide = currentSlide + slideOffset;
     if (lazyLoad && !infinite) {
-      targetSlide = (currentSlide + slidesToScroll) % slideCount + indexOffset;
+      targetSlide =
+        ((currentSlide + slidesToScroll) % slideCount) + indexOffset;
     }
   } else if (options.message === "dots") {
     // Click on dots
@@ -704,7 +705,7 @@ export const getTrackLeft = spec => {
       slideCount % slidesToScroll !== 0 &&
       slideIndex + slidesToScroll > slideCount
     ) {
-      slidesToOffset = slidesToShow - slideCount % slidesToScroll;
+      slidesToOffset = slidesToShow - (slideCount % slidesToScroll);
     }
     if (centerMode) {
       slidesToOffset = parseInt(slidesToShow / 2);
@@ -824,3 +825,14 @@ export const canUseDOM = () =>
     window.document &&
     window.document.createElement
   );
+
+const styleCache = {};
+export const getChildrenStyle = slidesPerRow => {
+  if (!styleCache[slidesPerRow]) {
+    styleCache[slidesPerRow] = {
+      width: `${100 / slidesPerRow}%`,
+      display: "inline-block"
+    };
+  }
+  return styleCache[slidesPerRow];
+};


### PR DESCRIPTION
Memoize style objects, so that Slider children can be pure components

In one of the projects I use many decorators calculating many operations in pictures (trimming, adding filters, etc.). PureComponent is the only solution in the child of the slider to stop costly re-rendering. That's what the fix is for.