### PR TITLE
Fix trackWidth for variableWidth

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -567,7 +567,11 @@ export const getTrackCSS = spec => {
   let trackWidth, trackHeight;
   const trackChildren = spec.slideCount + 2 * spec.slidesToShow;
   if (!spec.vertical) {
-    trackWidth = getTotalSlides(spec) * spec.slideWidth;
+    if (!spec.variableWidth) {
+      trackWidth = getTotalSlides(spec) * spec.slideWidth;
+    } else {
+      trackWidth = getTotalSlides(spec) * 5000;
+    }
   } else {
     trackHeight = trackChildren * spec.slideHeight;
   }


### PR DESCRIPTION
When using `variableWidth` the track-width is still computed with the `slideWidth`, which is wrong. In slick the fixed value of `5000` is used for this case:

```javacsript
else if (_.options.variableWidth === true) {
    _.$slideTrack.width(5000 * _.slideCount);
}
```

https://github.com/kenwheeler/slick/blob/master/slick/slick.js#L2081

This PR implements the same logic (use 5000 as fixed value for variableWidth) for react-slick