### PR TITLE
Fixed className provided to the appendDots component being overridden 

### DIFF
--- a/src/dots.js
+++ b/src/dots.js
@@ -67,8 +67,9 @@ export class Dots extends React.PureComponent {
       );
     });
 
-    return React.cloneElement(this.props.appendDots(dots), {
-      className: this.props.dotsClass,
+    const dotsList = this.props.appendDots(dots);
+    return React.cloneElement(dotsList, {
+      className: dotsList.props.className + " " + this.props.dotClass,
       ...mouseEvents
     });
   }

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -711,7 +711,8 @@ export class InnerSlider extends React.Component {
 
     let innerSliderProps = {
       className: className,
-      dir: "ltr"
+      dir: "ltr",
+      style:this.props.style
     };
 
     if (this.props.unslick) {

--- a/src/slider.js
+++ b/src/slider.js
@@ -208,7 +208,7 @@ export default class Slider extends React.Component {
       settings.unslick = true;
     }
     return (
-      <InnerSlider ref={this.innerSliderRefHandler} {...settings}>
+      <InnerSlider style={this.props.style} ref={this.innerSliderRefHandler} {...settings}>
         {newChildren}
       </InnerSlider>
     );


### PR DESCRIPTION
Fixed the className declaration being overridden by the slick-dots class. Now both the classes will be used. Fixes #1533 