### PR TITLE
Check for innerSlider

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -390,7 +390,7 @@ export class InnerSlider extends React.Component {
     );
     onLazyLoad && slidesToLoad.length > 0 && onLazyLoad(slidesToLoad);
     this.setState(state, () => {
-      asNavFor &&
+      asNavFor && asNavFor.innerSlider &&
         asNavFor.innerSlider.slideHandler(index);
       if (!nextState) return;
       this.animationEndCallback = setTimeout(() => {


### PR DESCRIPTION
Throws error if asNavFor.innerSlider does not exists. Happens when switching between pairs of maps (which I am looping over to build the slides) that do not have similar indexes. 