### PR TITLE
resolved slidesToScroll negative value issue

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -264,9 +264,7 @@ export class InnerSlider extends React.Component {
       };
       if (this.props.centerMode) {
         let currentWidth = `${childrenWidths[this.state.currentSlide]}px`;
-        trackStyle.left = `calc(${
-          trackStyle.left
-        } + (100% - ${currentWidth}) / 2 ) `;
+        trackStyle.left = `calc(${trackStyle.left} + (100% - ${currentWidth}) / 2 ) `;
       }
       this.setState({
         trackStyle
@@ -276,15 +274,15 @@ export class InnerSlider extends React.Component {
     let childrenCount = React.Children.count(this.props.children);
     const spec = { ...this.props, ...this.state, slideCount: childrenCount };
     let slideCount = getPreClones(spec) + getPostClones(spec) + childrenCount;
-    let trackWidth = 100 / this.props.slidesToShow * slideCount;
+    let trackWidth = (100 / this.props.slidesToShow) * slideCount;
     let slideWidth = 100 / slideCount;
     let trackLeft =
-      -slideWidth *
-      (getPreClones(spec) + this.state.currentSlide) *
-      trackWidth /
+      (-slideWidth *
+        (getPreClones(spec) + this.state.currentSlide) *
+        trackWidth) /
       100;
     if (this.props.centerMode) {
-      trackLeft += (100 - slideWidth * trackWidth / 100) / 2;
+      trackLeft += (100 - (slideWidth * trackWidth) / 100) / 2;
     }
     let trackStyle = {
       width: trackWidth + "%",
@@ -390,8 +388,7 @@ export class InnerSlider extends React.Component {
     );
     onLazyLoad && slidesToLoad.length > 0 && onLazyLoad(slidesToLoad);
     this.setState(state, () => {
-      asNavFor &&
-        asNavFor.innerSlider.slideHandler(index);
+      asNavFor && asNavFor.innerSlider.slideHandler(index);
       if (!nextState) return;
       this.animationEndCallback = setTimeout(() => {
         const { animating, ...firstBatch } = nextState;
@@ -626,7 +623,8 @@ export class InnerSlider extends React.Component {
     var dots;
     if (
       this.props.dots === true &&
-      this.state.slideCount >= this.props.slidesToShow
+      this.state.slideCount >= this.props.slidesToShow &&
+      this.props.slidesToScroll > 0 // Added to hide dots when slides to scroll is less than equal to 0
     ) {
       let dotProps = extractObject(spec, [
         "dotsClass",


### PR DESCRIPTION
This pull request will resolve issue id 1572 which is if the value of **slidesToScroll** is **-1** or **0** then the slider is throwing an error. Now in this PR the dots component will not render if **slidesToScroll: 0 | -1**.