### PR TITLE
Added option to use react-slick-styles to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install react-slick --save
 yarn add react-slick
 ```
 
-⚠️ Also install slick-carousel for css and font
+⚠️ Also install slick-carousel or [react-slick-styles](https://github.com/ivoilic/react-slick-styles) for css and font
 
 ```bash
 npm install slick-carousel
@@ -28,6 +28,14 @@ npm install slick-carousel
 // Import css files
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
+
+// or
+
+npm install react-slick-styles
+
+// Import css files
+import "react-slick-styles/slick/slick.css";
+import "react-slick-styles/slick/slick-theme.css";
 ```
 
 or add cdn link in your html


### PR DESCRIPTION
I created the [react-slick-styles](https://github.com/ivoilic/react-slick-styles) package to supplement react-slick. I understand why these styles files weren't included in this package but it seems wasteful to install the whole slick package just for the styles. Having a cut down package with just the styles gives people that option.