### PR TITLE
Validated when slidesToScroll is bellow of 0

### DIFF
--- a/src/dots.js
+++ b/src/dots.js
@@ -14,6 +14,11 @@ const getDotCount = spec => {
       1;
   }
 
+  if (dots < 0) {
+    const remainingAmount = parseInt(spec.slidesToScroll / spec.slideCount) + 1;
+    dots = spec.slideCount - remainingAmount;
+  }
+
   return dots;
 };
 


### PR DESCRIPTION
Fix issue #1572 

Now, when slidesToScroll is bellow of 0, is did one calc for get the position. Example:

We have 5 items, and the slidesToScroll is -2, so the value is the length os items less -2:
5 - 2 = 3. So the slidesToScroll will be 3. I hope that helps. :)