### PR TITLE
Change autoplay to false to true, it doesn't autoplay. This commit fi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slick",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -708,7 +708,8 @@ export class InnerSlider extends React.Component {
 
     let innerSliderProps = {
       className: className,
-      dir: "ltr"
+      dir: "ltr",
+      style:this.props.style
     };
 
     if (this.props.unslick) {

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -528,11 +528,7 @@ export class InnerSlider extends React.Component {
     }
     const autoplaying = this.state.autoplaying;
     if (playType === "update") {
-      if (
-        autoplaying === "hovered" ||
-        autoplaying === "focused" ||
-        autoplaying === "paused"
-      ) {
+      if (autoplaying === "hovered" || autoplaying === "focused") {
         return;
       }
     } else if (playType === "leave") {
@@ -709,7 +705,7 @@ export class InnerSlider extends React.Component {
     let innerSliderProps = {
       className: className,
       dir: "ltr",
-      style:this.props.style
+      style: this.props.style
     };
 
     if (this.props.unslick) {

--- a/src/slider.js
+++ b/src/slider.js
@@ -202,7 +202,7 @@ export default class Slider extends React.Component {
       settings.unslick = true;
     }
     return (
-      <InnerSlider ref={this.innerSliderRefHandler} {...settings}>
+      <InnerSlider style={this.props.style} ref={this.innerSliderRefHandler} {...settings}>
         {newChildren}
       </InnerSlider>
     );


### PR DESCRIPTION
Fix issue [1634](https://github.com/akiran/react-slick/issues/1634). 
When default autoplay is false, we try to change it to autoplay true it doesn't work. Here is issue demo [Issue](https://codesandbox.io/s/react-slick-playground-unyot).

This is due to ``autoplaying state : paused``. It is returning from here. It is not updating autoplay property. I have fixed this by removing this.