### PR TITLE
Fix unslick missing children element

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -197,7 +197,7 @@ export default class Slider extends React.Component {
 
     if (settings === "unslick") {
       const className = "regular slider " + (this.props.className || "");
-      return <div className={className}>{newChildren}</div>;
+      return <span className={className}>{children}</span>;
     } else if (newChildren.length <= settings.slidesToShow) {
       settings.unslick = true;
     }


### PR DESCRIPTION
**1.** When set unslick the children element went missing so use variable `children` to render from given children instead of `newChildren`. 

## Before
<img width="1565" alt="Screen Shot 2019-10-11 at 3 15 21 PM" src="https://user-images.githubusercontent.com/1607019/66635752-1240b680-ec3a-11e9-9e27-6753f59d58c8.png">

**2.** Change `div` to `span` because it fixed element doesn't load properly on the breakpoint that set unslick (Don't know the root cause but it works like a charm.)

## Before
<img width="1553" alt="Screen Shot 2019-10-11 at 3 10 50 PM" src="https://user-images.githubusercontent.com/1607019/66635829-2dabc180-ec3a-11e9-950a-731ea2a78f15.png">

## After
<img width="1551" alt="Screen Shot 2019-10-11 at 3 12 24 PM" src="https://user-images.githubusercontent.com/1607019/66635770-1967c480-ec3a-11e9-8e2d-407bfaa49c54.png">

Example settings
```js
  var settings = {
      infinite: false,
      speed: 500,
      slidesToShow: 5,
      slidesToScroll: 1,
      responsive: [
        {
          breakpoint: 480,
          settings: {
            centerMode: true,
            slidesToShow: 2,
            slidesToScroll: 1,
            infinite: true
          },
        }, {
          breakpoint: 10000,
          settings: 'unslick'
        }
      ]
  }
```