### PR TITLE
fix ondemand lazy loading for uneven sets

### DIFF
--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -20,6 +20,7 @@ import Rtl from '../examples/Rtl'
 import VariableWidth from '../examples/VariableWidth'
 import AdaptiveHeight from '../examples/AdaptiveHeight'
 import LazyLoad from '../examples/LazyLoad'
+import LazyLoadUnevenSets from '../examples/LazyLoadUnevenSets'
 import Fade from '../examples/Fade'
 import SlickGoTo from '../examples/SlickGoTo'
 import CustomArrows from '../examples/CustomArrows'
@@ -53,6 +54,7 @@ export default class App extends React.Component {
         <VariableWidth />
         <AdaptiveHeight />
         <LazyLoad />
+        <LazyLoadUnevenSets />
         <Fade />
         <SlideChangeHooks />
         <SlickGoTo />

--- a/examples/LazyLoadUnevenSets.js
+++ b/examples/LazyLoadUnevenSets.js
@@ -1,0 +1,44 @@
+import React, { Component } from "react";
+import Slider from "../src/slider";
+import { baseUrl } from "./config";
+
+export default class LazyLoadUnevenSets extends Component {
+  render() {
+    const settings = {
+      dots: true,
+      lazyLoad: true,
+      infinite: true,
+      slidesToShow: 3,
+      slidesToScroll: 3,
+      speed: 500
+    };
+    return (
+      <div>
+        <h2> Lazy Load Uneven Sets </h2>
+        <Slider {...settings}>
+          <div>
+            <img src={baseUrl + "/abstract01.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract02.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract03.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract04.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract01.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract02.jpg"} />
+          </div>
+          <div>
+            <img src={baseUrl + "/abstract03.jpg"} />
+          </div>
+        </Slider>
+      </div>
+    );
+  }
+}

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -28,11 +28,23 @@ export const getRequiredLazySlides = spec => {
 export const lazyStartIndex = spec =>
   spec.currentSlide - lazySlidesOnLeft(spec);
 export const lazyEndIndex = spec => spec.currentSlide + lazySlidesOnRight(spec);
-export const lazySlidesOnLeft = spec =>
-  spec.centerMode
-    ? Math.floor(spec.slidesToShow / 2) +
+export const lazySlidesOnLeft = spec => {
+  if (spec.centerMode) {
+    return (
+      Math.floor(spec.slidesToShow / 2) +
       (parseInt(spec.centerPadding) > 0 ? 1 : 0)
-    : 0;
+    );
+  }
+
+  const numPages = Math.ceil(spec.slideCount / spec.slidesToShow);
+  const lastPageStartIndex = (numPages - 1) * spec.slidesToShow;
+
+  if (spec.currentSlide >= lastPageStartIndex) {
+    return spec.currentSlide + spec.slidesToShow - spec.slideCount;
+  }
+
+  return 0;
+};
 export const lazySlidesOnRight = spec =>
   spec.centerMode
     ? Math.floor((spec.slidesToShow - 1) / 2) +
@@ -48,7 +60,7 @@ export const getSwipeDirection = (touchObject, verticalSwiping = false) => {
   xDist = touchObject.startX - touchObject.curX;
   yDist = touchObject.startY - touchObject.curY;
   r = Math.atan2(yDist, xDist);
-  swipeAngle = Math.round(r * 180 / Math.PI);
+  swipeAngle = Math.round((r * 180) / Math.PI);
   if (swipeAngle < 0) {
     swipeAngle = 360 - Math.abs(swipeAngle);
   }
@@ -195,7 +207,7 @@ export const slideHandler = spec => {
       finalSlide = animationSlide + slideCount;
       if (!infinite) finalSlide = 0;
       else if (slideCount % slidesToScroll !== 0)
-        finalSlide = slideCount - slideCount % slidesToScroll;
+        finalSlide = slideCount - (slideCount % slidesToScroll);
     } else if (!canGoNext(spec) && animationSlide > currentSlide) {
       animationSlide = finalSlide = currentSlide;
     } else if (centerMode && animationSlide >= slideCount) {
@@ -265,7 +277,8 @@ export const changeSlide = (spec, options) => {
     slideOffset = indexOffset === 0 ? slidesToScroll : indexOffset;
     targetSlide = currentSlide + slideOffset;
     if (lazyLoad && !infinite) {
-      targetSlide = (currentSlide + slidesToScroll) % slideCount + indexOffset;
+      targetSlide =
+        ((currentSlide + slidesToScroll) % slideCount) + indexOffset;
     }
   } else if (options.message === "dots") {
     // Click on dots
@@ -704,7 +717,7 @@ export const getTrackLeft = spec => {
       slideCount % slidesToScroll !== 0 &&
       slideIndex + slidesToScroll > slideCount
     ) {
-      slidesToOffset = slidesToShow - slideCount % slidesToScroll;
+      slidesToOffset = slidesToShow - (slideCount % slidesToScroll);
     }
     if (centerMode) {
       slidesToOffset = parseInt(slidesToShow / 2);


### PR DESCRIPTION
Fixes #1323 

I added an example in the demo that showcases the issue. Against the old code it if you click on the last page it wouldn't show the previous two images until you visit page 2.