### PR TITLE
 addionally enable pinch-zoom handling by browser on ios 13

### DIFF
--- a/docs/slick.css
+++ b/docs/slick.css
@@ -14,7 +14,7 @@
     -webkit-touch-callout: none;
     -khtml-user-select: none;
     -ms-touch-action: pan-y;
-        touch-action: pan-y;
+        touch-action: pan-y pinch-zoom;
     -webkit-tap-highlight-color: transparent;
 }
 


### PR DESCRIPTION
Solved our problem on running on iOS 13 devices in production.

This enables the pinch-zoom gesture on the new iOS 13 version, again.

Please add this info to the documentation.

In our project we ran in to the issue, that Safari blocked zooming when the slider is hidden behind a modal overlay dialog!



closes #1640