### PR TITLE
refactor: remove deprecated vendor prefix

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -68,16 +68,6 @@ const getSlideStyle = spec => {
       spec.speed +
       "ms " +
       spec.cssEase;
-    style.WebkitTransition =
-      "opacity " +
-      spec.speed +
-      "ms " +
-      spec.cssEase +
-      ", " +
-      "visibility " +
-      spec.speed +
-      "ms " +
-      spec.cssEase;
   }
 
   return style;


### PR DESCRIPTION
the last browsers requiring webkit vendor prefix is about 6years ago.
it's good enough to remove it.