### PR TITLE
refactor: no componentDidMount called on server

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -97,10 +97,6 @@ export class InnerSlider extends React.Component {
         slide.onblur = this.props.pauseOnFocus ? this.onSlideBlur : null;
       }
     );
-    // To support server-side rendering
-    if (!window) {
-      return;
-    }
     if (window.addEventListener) {
       window.addEventListener("resize", this.onWindowResized);
     } else {


### PR DESCRIPTION
There is no case componentDidMount that will be called on server side.
Good to not have the guard