### PR TITLE
[Docs]: Added reference to contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ open http://localhost:8080
   <img src="https://opencollective.com/react-slick/donate/button@2x.png?color=blue" width=300 />
 </a>
 
+## Contributing
+
+Please see the [contributing guidelines](./CONTRIBUTING.md)
+
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].


### PR DESCRIPTION
It is a good practice to add reference to the `contributing guidelines` as part of the docs which the users might miss out if otherwise.