### PR TITLE
fix: to handle image.onload event correctly

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -290,7 +290,7 @@ export class InnerSlider extends React.Component {
     });
   };
   checkImagesLoad = () => {
-    let images = document.querySelectorAll(".slick-slide img");
+    let images = this.list.querySelectorAll(".slick-slide img");
     let imagesCount = images.length,
       loadedCount = 0;
     Array.prototype.forEach.call(images, image => {
@@ -705,7 +705,7 @@ export class InnerSlider extends React.Component {
     let innerSliderProps = {
       className: className,
       dir: "ltr",
-      style:this.props.style
+      style: this.props.style
     };
 
     if (this.props.unslick) {


### PR DESCRIPTION
Fix #1356 

`document.querySelectorAll(".slick-slide img")` selector will select all images under `.slick-slide` and add onload event on those images.  if there are multiple react-slick instance on the same page, the image.onload event may be handled by other react-slick instance . 

This commit aims to fix the issue by searching `".slick-slide img"` in the list reference instead of document.
