### PR TITLE
Change childNodes attribute to children as per other usage

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -723,7 +723,7 @@ export const getTrackLeft = spec => {
     var targetSlideIndex;
     let trackElem = ReactDOM.findDOMNode(trackRef);
     targetSlideIndex = slideIndex + getPreClones(spec);
-    targetSlide = trackElem && trackElem.childNodes[targetSlideIndex];
+    targetSlide = trackElem && trackElem.children[targetSlideIndex];
     targetLeft = targetSlide ? targetSlide.offsetLeft * -1 : 0;
     if (centerMode === true) {
       targetSlideIndex = infinite


### PR DESCRIPTION
This change is to fix usage of `childNodes` which is breaking in test environments, and change it to `children` as per the rest of the code block.