### PR TITLE
#1753: Fix center break issue by focus event when slider Item has img…

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -297,10 +297,16 @@ export class InnerSlider extends React.Component {
       const handler = () =>
         ++loadedCount && loadedCount >= imagesCount && this.onWindowResized();
       if (!image.onclick) {
-        image.onclick = () => image.parentNode.focus();
+        image.onclick = () => {
+          if (this.props.centerMode) return;
+
+          image.parentNode.focus();
+        };
       } else {
         const prevClickHandler = image.onclick;
         image.onclick = () => {
+          if (this.props.centerMode) return;
+
           prevClickHandler();
           image.parentNode.focus();
         };
@@ -705,7 +711,7 @@ export class InnerSlider extends React.Component {
     let innerSliderProps = {
       className: className,
       dir: "ltr",
-      style:this.props.style
+      style: this.props.style
     };
 
     if (this.props.unslick) {


### PR DESCRIPTION
… tag.

Reference: https://github.com/akiran/react-slick/issues/1753

I fixed by blocking the focus event when "centerMode" with true.

I am guessing there is a reason that you focus img tag if there is img in the slider item.

If this is not a way you recommend, please let me know how you prefer to fix the issue.
I am willing to help. :)