### PR TITLE
Fix: wait for animate (#1415)

### DIFF
--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -32,6 +32,7 @@ import CustomPaging from '../examples/CustomPaging'
 import CustomSlides from '../examples/CustomSlides'
 import AsNavFor from '../examples/AsNavFor'
 import AppendDots from '../examples/AppendDots'
+import WaitForAnimate from '../examples/WaitForAnimate';
 
 export default class App extends React.Component {
   render() {
@@ -66,6 +67,7 @@ export default class App extends React.Component {
         <VerticalSwipeToSlide />
         <AsNavFor />
         <AppendDots />
+        <WaitForAnimate/>
       </div>
     );
   }

--- a/examples/WaitForAnimate.js
+++ b/examples/WaitForAnimate.js
@@ -1,0 +1,46 @@
+import React, { Component } from "react";
+import Slider from "../src/slider";
+
+export default class WaitForAnimate extends Component {
+  render() {
+    const settings = {
+      speed: 2000,
+      waitForAnimate: false
+    };
+
+    const onClick = () => {
+      setTimeout(() => this.slider.slickNext(), 0);
+      setTimeout(() => this.slider.slickPrev(), 600);
+      setTimeout(() => this.slider.slickNext(), 1200);
+    };
+
+    return (
+      <div>
+        <h2>Wait for animate</h2>
+        <button onClick={onClick}>
+          click me to trigger next / prev / next
+        </button>
+        <Slider {...settings} ref={slider => (this.slider = slider)}>
+          <div>
+            <h3>1</h3>
+          </div>
+          <div>
+            <h3>2</h3>
+          </div>
+          <div>
+            <h3>3</h3>
+          </div>
+          <div>
+            <h3>4</h3>
+          </div>
+          <div>
+            <h3>5</h3>
+          </div>
+          <div>
+            <h3>6</h3>
+          </div>
+        </Slider>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
This change makes sure that there is no "jumps" in the animation when `waitForAnimate` is set to `false` and consecutive navigations are triggered.
It does so by canceling the current animation callback and applying the current transformation as a style before triggering the next animation.
Closes #1415

Before:
https://codesandbox.io/s/react-slick-playground-x1pyh?file=/index.js

After:
https://codesandbox.io/s/react-slick-playground-vdwnu?file=/index.js

For the record, here are some thread that led me to this solution:
- https://stackoverflow.com/questions/55646196/css-transformation-change-during-transition-causes-current-state-to-get-lost-and
- https://semisignal.com/triggering-reflow-for-css3-transitions/

I don't have a deep knowledge of the codebase so you might do some refactoring to integrate the fix better than I did but I think that the core of the solution is there.