### PR TITLE
default children return in case of unslick

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -197,12 +197,16 @@ export default class Slider extends React.Component {
 
     if (settings === "unslick") {
       const className = "regular slider " + (this.props.className || "");
-      return <div className={className}>{newChildren}</div>;
+      return <div className={className}>{children}</div>;
     } else if (newChildren.length <= settings.slidesToShow) {
       settings.unslick = true;
     }
     return (
-      <InnerSlider style={this.props.style} ref={this.innerSliderRefHandler} {...settings}>
+      <InnerSlider
+        style={this.props.style}
+        ref={this.innerSliderRefHandler}
+        {...settings}
+      >
         {newChildren}
       </InnerSlider>
     );


### PR DESCRIPTION
This PR will fix this [issue-1663](https://github.com/akiran/react-slick/issues/1663)
Due to parent settings variable, newChildren was always giving blank children. In the case of unslick, we should return direct children.