### PR TITLE
Fix variableWidth with large slides

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -126,7 +126,11 @@ export const initializedState = spec => {
     currentSlide = slideCount - 1 - spec.initialSlide;
   }
   let lazyLoadedList = spec.lazyLoadedList || [];
-  let slidesToLoad = getOnDemandLazySlides({ ...spec, currentSlide, lazyLoadedList });
+  let slidesToLoad = getOnDemandLazySlides({
+    ...spec,
+    currentSlide,
+    lazyLoadedList
+  });
   lazyLoadedList.concat(slidesToLoad);
 
   let state = {
@@ -565,7 +569,11 @@ export const getTrackCSS = spec => {
   let trackWidth, trackHeight;
   const trackChildren = spec.slideCount + 2 * spec.slidesToShow;
   if (!spec.vertical) {
-    trackWidth = getTotalSlides(spec) * spec.slideWidth;
+    // We take 3 times the width of the children because of the preClones and postClones.
+    trackWidth = spec.variableWidth
+      ? spec.children.reduce((sum, child) => sum + child.props.style.width, 0) *
+        3
+      : getTotalSlides(spec) * spec.slideWidth;
   } else {
     trackHeight = trackChildren * spec.slideHeight;
   }


### PR DESCRIPTION
Changes the way trackWidth is calculated when the `variableWidth` flag is set to true.
Now the trackWidth is calculated by adding the width of all children and multiplying it by 3 (adds the preClones and postClones width).

See issue #1789.