### PR TITLE
fixed event collision between drag/swipe and click events

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -687,11 +687,12 @@ export class InnerSlider extends React.Component {
     }
 
     const listStyle = { ...verticalHeightStyle, ...centerPaddingStyle };
-    const touchMove = this.props.touchMove;
+    const { draggable, touchMove } = this.props;
     let listProps = {
       className: "slick-list",
       style: listStyle,
-      onClick: this.clickHandler,
+      onClick: !draggable && !touchMove ? this.clickHandler : null,
+      onClickCapture: draggable || touchMove ? this.clickHandler : null,
       onMouseDown: touchMove ? this.swipeStart : null,
       onMouseMove: this.state.dragging && touchMove ? this.swipeMove : null,
       onMouseUp: touchMove ? this.swipeEnd : null,

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -126,7 +126,11 @@ export const initializedState = spec => {
     currentSlide = slideCount - 1 - spec.initialSlide;
   }
   let lazyLoadedList = spec.lazyLoadedList || [];
-  let slidesToLoad = getOnDemandLazySlides({ ...spec, currentSlide, lazyLoadedList });
+  let slidesToLoad = getOnDemandLazySlides({
+    ...spec,
+    currentSlide,
+    lazyLoadedList
+  });
   lazyLoadedList.concat(slidesToLoad);
 
   let state = {
@@ -335,7 +339,8 @@ export const swipeMove = (e, spec) => {
     touchObject,
     swipeEvent,
     listHeight,
-    listWidth
+    listWidth,
+    minSwipeLength = 10
   } = spec;
   if (scrolling) return;
   if (animating) return e.preventDefault();
@@ -405,7 +410,7 @@ export const swipeMove = (e, spec) => {
   ) {
     return state;
   }
-  if (touchObject.swipeLength > 10) {
+  if (touchObject.swipeLength > minSwipeLength) {
     state["swiping"] = true;
     e.preventDefault();
   }


### PR DESCRIPTION
When using `button` elements with an `onClick` the `onClick` event would always be fired after dragging due to the way event bubbling works. The `onClick` handler would be the first element to fire, before bubbling up to Slick Slider instead of the other way around.

This PR fixes that issue and also allows a user to define the minimum threshold a user should swipe/drag before invalidating click events on its items.