### PR TITLE
initialSlide not always honored; possible fix for issue #1809 

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -149,7 +149,7 @@ export class InnerSlider extends React.Component {
       }
     }
     this.updateState(spec, setTrackStyle, () => {
-      if (this.state.currentSlide >= React.Children.count(nextProps.children)) {
+      if (this.state.currentSlide > React.Children.count(nextProps.children)) {
         this.changeSlide({
           message: "index",
           index:


### PR DESCRIPTION
When first loading, with initialSlide set to zero and slidesToShow greater than one, the internal currentSlide would become negative.  It's crucial that the intended first slide always be the actual first one visible.

It's possible that is only happens when in infinite mode.