### PR TITLE
Fixes canGoNext when in center mode.

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -78,8 +78,9 @@ export const canGoNext = spec => {
     if (spec.centerMode && spec.currentSlide >= spec.slideCount - 1) {
       canGo = false;
     } else if (
-      spec.slideCount <= spec.slidesToShow ||
-      spec.currentSlide >= spec.slideCount - spec.slidesToShow
+      !spec.centerMode &&
+      (spec.slideCount <= spec.slidesToShow ||
+        spec.currentSlide >= spec.slideCount - spec.slidesToShow)
     ) {
       canGo = false;
     }


### PR DESCRIPTION
This copies over a commit from an earlier fork that
is needed to ensure all images can be seen in storefront carousels.