### PR TITLE
fix typo

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -19,7 +19,7 @@ export default class Slider extends React.Component {
   innerSliderRefHandler = ref => (this.innerSlider = ref);
 
   media(query, handler) {
-    // javascript handler for  css media query
+    // javascript handler for css media query
     enquire.register(query, handler);
     this._responsiveMediaHandlers.push({ query, handler });
   }


### PR DESCRIPTION
I found typo in `slider.js` and fixed it.