### PR TITLE
Show the correct amount of items when navigating to previous page

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -199,8 +199,6 @@ export const slideHandler = spec => {
     if (animationSlide < 0) {
       finalSlide = animationSlide + slideCount;
       if (!infinite) finalSlide = 0;
-      else if (slideCount % slidesToScroll !== 0)
-        finalSlide = slideCount - (slideCount % slidesToScroll);
     } else if (!canGoNext(spec) && animationSlide > currentSlide) {
       animationSlide = finalSlide = currentSlide;
     } else if (centerMode && animationSlide >= slideCount) {


### PR DESCRIPTION
I have a Slider with 21 Items and show 6 slides per page. When navigating to a previous Page initially only 3 items are displayed. Because finalSlide becomes 18 and not 15 like it should be.

![image](https://user-images.githubusercontent.com/9765622/95562553-97f96c80-0a1c-11eb-884a-869b5762e622.png)

I can't find the reason this extra clause existed in the slideHandle function, I have tracked it back via git blame to this commit https://github.com/akiran/react-slick/commit/86b721896f1edbcac3c602fb6c28caf9047670c2 But there isn't much explanation why. 

With this change the correct amount of items are displayed.