### PR TITLE
Fix broken slide when slide content is wrapped in a tag. issue #1316

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -316,6 +316,7 @@ export const keyHandler = (e, accessibility, rtl) => {
 
 export const swipeStart = (e, swipe, draggable) => {
   e.target.tagName === "IMG" && e.preventDefault();
+  e.target.tagName === "A" && e.preventDefault();
   if (!swipe || (!draggable && e.type.indexOf("mouse") !== -1)) return "";
   return {
     dragging: true,


### PR DESCRIPTION
Related to the issue from @selrond https://github.com/akiran/react-slick/issues/1316#issue-341951239 

As with IMG, we should be able to swipe when there is an A tag in the slide content. A tag became draggable when href is setted.