### PR TITLE
Add config option to change number of lazy loaded items by multiplyin…

### DIFF
--- a/__tests__/lazyLoad.test.js
+++ b/__tests__/lazyLoad.test.js
@@ -49,11 +49,12 @@ describe("LazyLoad test", () => {
     lazyLoad: true,
     useCSS: false,
     speed: 0,
-    noOfSlides: [7, 8],
-    initialSlide: [0, 5],
+    noOfSlides: [12, 15],
+    initialSlide: [0, 3],
     slidesToShow: [1, 3, 4],
     slidesToScroll: [1, 3],
-    centerMode: [true, false]
+    centerMode: [true, false],
+    ondemandLazyPageMultiplier: [0, 1, 2]
   };
   let settingsList = [];
   tryAllConfigs(settings, settingsList);

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -41,6 +41,9 @@ export const lazySlidesOnRight = spec =>
     ? Math.floor((spec.slidesToShow - 1) / 2) +
       1 +
       (parseInt(spec.centerPadding) > 0 ? 1 : 0)
+    : typeof spec.ondemandLazyPageMultiplier === "number" &&
+      spec.ondemandLazyPageMultiplier > 0
+    ? spec.slidesToShow * spec.ondemandLazyPageMultiplier
     : spec.slidesToShow;
 
 // get width of an element


### PR DESCRIPTION
This change provides a new prop `ondemandLazyPageMultiplier` that allows you to scale the number of images that `ondemand` lazy loading loads.

The issue at hand is that you may want to load the n+1 pages, instead of n pages, thus when the user navigates to the next page, the items are loaded (in this case, `ondemandLazyPageMultiplier` would be 2).