### PR TITLE
Need to enforce images list validation

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -304,7 +304,7 @@ export class InnerSlider extends React.Component {
   };
   checkImagesLoad = () => {
     let images =
-      (this.list.querySelectorAll &&
+      (this.list && this.list.querySelectorAll &&
         this.list.querySelectorAll(".slick-slide img")) ||
       [];
     let imagesCount = images.length,


### PR DESCRIPTION
In some cases, for instance while running some tests via storyshot, we can get a blocker with this error message:

`Error: Uncaught [TypeError: Cannot read property 'querySelectorAll' of undefined]`

Adding `this.list &&` at the beginning of this test will avoid such of issues and let pass well the tests

I would really appreciate that fix to be able to move forward from `0.25.2` of react-slick to the latest version

Thanks