### PR TITLE
Add support for accessibility for custom dots

### DIFF
--- a/src/dots.js
+++ b/src/dots.js
@@ -70,7 +70,7 @@ export class Dots extends React.PureComponent {
 
       let onClick = this.clickHandler.bind(this, dotOptions);
       dots = dots.concat(
-        <li key={i} className={className}>
+        <li key={i} className={className} role="listitem">
           {React.cloneElement(this.props.customPaging(i), { onClick })}
         </li>
       );


### PR DESCRIPTION
In accessibility the order is important so we need to have the role assigned on <li> element because it's not touchable from current API (I can touch wrap or add element inside of <li>).

More info:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Listitem_role