### PR TITLE
Fixed issue 1987

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -84,7 +84,7 @@ const getSlideStyle = spec => {
   return style;
 };
 
-const getKey = (child, fallbackKey) => child.key || fallbackKey;
+const getKey = (child, fallbackKey) => child.key || 'fallback-' + fallbackKey;
 
 const renderSlides = spec => {
   let key;


### PR DESCRIPTION
Fixed issue: #1987 (Two children with the same key error when using row, lazyLoading and infinite.)

Author fix: @lioryemini