### PR TITLE
Fix wrong animation for slickGoTo

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -6,10 +6,10 @@ export function clamp(number, lowerBound, upperBound) {
 
 export const safePreventDefault = event => {
   const passiveEvents = ["onTouchStart", "onTouchMove", "onWheel"];
-  if(!passiveEvents.includes(event._reactName)) {
+  if (!passiveEvents.includes(event._reactName)) {
     event.preventDefault();
   }
-}
+};
 
 export const getOnDemandLazySlides = spec => {
   let onDemandSlides = [];
@@ -297,7 +297,13 @@ export const changeSlide = (spec, options) => {
     }
   } else if (options.message === "dots") {
     // Click on dots
-    targetSlide = options.index * options.slidesToScroll;
+    if (options.index === currentSlide) {
+      targetSlide = options.index;
+    } else if (slideCount === options.index + 1 && currentSlide === 0) {
+      targetSlide = -1;
+    } else {
+      targetSlide = options.index * options.slidesToScroll || slideCount;
+    }
   } else if (options.message === "children") {
     // Click on the slides
     targetSlide = options.index;
@@ -386,9 +392,12 @@ export const swipeMove = (e, spec) => {
   let touchSwipeLength = touchObject.swipeLength;
   if (!infinite) {
     if (
-      (currentSlide === 0 && (swipeDirection === "right" || swipeDirection === "down")) ||
-      (currentSlide + 1 >= dotCount && (swipeDirection === "left" || swipeDirection === "up")) ||
-      (!canGoNext(spec) && (swipeDirection === "left" || swipeDirection === "up"))
+      (currentSlide === 0 &&
+        (swipeDirection === "right" || swipeDirection === "down")) ||
+      (currentSlide + 1 >= dotCount &&
+        (swipeDirection === "left" || swipeDirection === "up")) ||
+      (!canGoNext(spec) &&
+        (swipeDirection === "left" || swipeDirection === "up"))
     ) {
       touchSwipeLength = touchObject.swipeLength * edgeFriction;
       if (edgeDragged === false && onEdge) {


### PR DESCRIPTION
This PR fixes #1869 

Pretty straight forward change on innerSlideUtils to function `changeSlide` which didn't have any treatments for swapping just one slide when in the first or last position.'

Before
![before](https://user-images.githubusercontent.com/50468019/124924666-0f6f2300-dfd2-11eb-983f-856a9cb99576.gif)


After:
![after](https://user-images.githubusercontent.com/50468019/124924690-15fd9a80-dfd2-11eb-91bc-c2f2f8e2b924.gif)


