### PR TITLE
Swap prev arrow position to avoid overlapping on other DOM elements

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -304,7 +304,8 @@ export class InnerSlider extends React.Component {
   };
   checkImagesLoad = () => {
     let images =
-      (this.list && this.list.querySelectorAll &&
+      (this.list &&
+        this.list.querySelectorAll &&
         this.list.querySelectorAll(".slick-slide img")) ||
       [];
     let imagesCount = images.length,
@@ -751,12 +752,12 @@ export class InnerSlider extends React.Component {
     }
     return (
       <div {...innerSliderProps}>
-        {!this.props.unslick ? prevArrow : ""}
         <div ref={this.listRefHandler} {...listProps}>
           <Track ref={this.trackRefHandler} {...trackProps}>
             {this.props.children}
           </Track>
         </div>
+        {!this.props.unslick ? prevArrow : ""}
         {!this.props.unslick ? nextArrow : ""}
         {!this.props.unslick ? dots : ""}
       </div>


### PR DESCRIPTION
As mentioned on issue #2045 there's a problem of overlapping when the prev arrow is first positioned on component structure. 