### PR TITLE
Replace classnames with clsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "why-did-you-update": "^0.1.1"
   },
   "dependencies": {
-    "classnames": "^2.2.5",
+    "clsx": "^1.1.1",
     "enquire.js": "^2.1.6",
     "json2mq": "^0.2.0",
     "lodash.debounce": "^4.0.8",

--- a/src/arrows.js
+++ b/src/arrows.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import React from "react";
-import classnames from "classnames";
+import clsx from "clsx";
 import { canGoNext } from "./utils/innerSliderUtils";
 
 export class PrevArrow extends React.PureComponent {
@@ -27,7 +27,7 @@ export class PrevArrow extends React.PureComponent {
     let prevArrowProps = {
       key: "0",
       "data-role": "none",
-      className: classnames(prevClasses),
+      className: clsx(prevClasses),
       style: { display: "block" },
       onClick: prevHandler
     };
@@ -74,7 +74,7 @@ export class NextArrow extends React.PureComponent {
     let nextArrowProps = {
       key: "1",
       "data-role": "none",
-      className: classnames(nextClasses),
+      className: clsx(nextClasses),
       style: { display: "block" },
       onClick: nextHandler
     };

--- a/src/dots.js
+++ b/src/dots.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import React from "react";
-import classnames from "classnames";
+import clsx from "clsx";
 import { clamp } from "./utils/innerSliderUtils";
 
 const getDotCount = spec => {
@@ -55,7 +55,7 @@ export class Dots extends React.PureComponent {
         ? _leftBound
         : clamp(_leftBound, 0, slideCount - 1);
 
-      let className = classnames({
+      let className = clsx({
         "slick-active": infinite
           ? currentSlide >= leftBound && currentSlide <= rightBound
           : currentSlide === leftBound

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -3,7 +3,7 @@
 import React from "react";
 import initialState from "./initial-state";
 import debounce from "lodash.debounce";
-import classnames from "classnames";
+import clsx from "clsx";
 import {
   getOnDemandLazySlides,
   extractObject,
@@ -613,7 +613,7 @@ export class InnerSlider extends React.Component {
     this.autoPlay("blur");
 
   render = () => {
-    var className = classnames("slick-slider", this.props.className, {
+    var className = clsx("slick-slider", this.props.className, {
       "slick-vertical": this.props.vertical,
       "slick-initialized": true
     });

--- a/src/track.js
+++ b/src/track.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import React from "react";
-import classnames from "classnames";
+import clsx from "clsx";
 import {
   lazyStartIndex,
   lazyEndIndex,
@@ -121,7 +121,7 @@ const renderSlides = spec => {
       React.cloneElement(child, {
         key: "original" + getKey(child, index),
         "data-index": index,
-        className: classnames(slideClasses, slideClass),
+        className: clsx(slideClasses, slideClass),
         tabIndex: "-1",
         "aria-hidden": !slideClasses["slick-active"],
         style: { outline: "none", ...(child.props.style || {}), ...childStyle },
@@ -151,7 +151,7 @@ const renderSlides = spec => {
             key: "precloned" + getKey(child, key),
             "data-index": key,
             tabIndex: "-1",
-            className: classnames(slideClasses, slideClass),
+            className: clsx(slideClasses, slideClass),
             "aria-hidden": !slideClasses["slick-active"],
             style: { ...(child.props.style || {}), ...childStyle },
             onClick: e => {
@@ -175,7 +175,7 @@ const renderSlides = spec => {
             key: "postcloned" + getKey(child, key),
             "data-index": key,
             tabIndex: "-1",
-            className: classnames(slideClasses, slideClass),
+            className: clsx(slideClasses, slideClass),
             "aria-hidden": !slideClasses["slick-active"],
             style: { ...(child.props.style || {}), ...childStyle },
             onClick: e => {


### PR DESCRIPTION
clsx is fully compatible with classnames API, is quickly gaining traction and is about 1/3rd smaller than classnames.