### PR TITLE
dots: add slider settings in custom paging

### DIFF
--- a/examples/CustomPaging.js
+++ b/examples/CustomPaging.js
@@ -2,15 +2,32 @@ import React, { Component } from "react";
 import Slider from "../src/slider";
 import { baseUrl } from "./config";
 
+class Paging extends Component {
+  render() {
+    const {
+      slidesToScroll,
+      currentSlide,
+      slidesToShow,
+      slideCount,
+      index,
+      onClick
+    } = this.props;
+
+    const pagination = `${index + 1} / ${slideCount}`;
+    return (
+      <a onClick={onClick}>
+        <img src={`${baseUrl}/abstract0${index + 1}.jpg`} />
+        <span>{pagination}</span>
+      </a>
+    );
+  }
+}
+
 export default class CenterMode extends Component {
   render() {
     const settings = {
-      customPaging: function(i) {
-        return (
-          <a>
-            <img src={`${baseUrl}/abstract0${i + 1}.jpg`} />
-          </a>
-        );
+      customPaging: function(i, sliderSettings) {
+        return <Paging {...sliderSettings} index={i} />;
       },
       dots: true,
       dotsClass: "slick-dots slick-thumb",

--- a/src/dots.js
+++ b/src/dots.js
@@ -71,7 +71,15 @@ export class Dots extends React.PureComponent {
       let onClick = this.clickHandler.bind(this, dotOptions);
       dots = dots.concat(
         <li key={i} className={className}>
-          {React.cloneElement(this.props.customPaging(i), { onClick })}
+          {React.cloneElement(
+            this.props.customPaging(i, {
+              slidesToScroll,
+              currentSlide,
+              slidesToShow,
+              slideCount
+            }),
+            { onClick }
+          )}
         </li>
       );
     }


### PR DESCRIPTION
Pass slider settings to custom paging function in order to display "index / slidescount" needed for accessibility reasons mainly.
Exemple update to illustrate.