### PR TITLE
set settings.infinite false when number of children <= slidesToShow to fix slick cloned slides bug

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -200,6 +200,7 @@ export default class Slider extends React.Component {
       return <div className={className}>{children}</div>;
     } else if (newChildren.length <= settings.slidesToShow) {
       settings.unslick = true;
+      settings.infinite = false;
     }
     return (
       <InnerSlider


### PR DESCRIPTION
This PR fixes  #1569
I kept the functionality of setting the unslick to true when the number of children is inferior or equal to the number of slides to show. I set infinite to false to avoid the duplicates.

Example with 4 children and slidesToShow: 5.
Before: 
![image](https://user-images.githubusercontent.com/18199338/148467259-c3409143-9f54-4dd0-9c44-e45c4ecc0d76.png)

After:
![image](https://user-images.githubusercontent.com/18199338/148467136-f8c77837-5b9b-46b6-bec0-509265e803e2.png)
 