### PR TITLE
fix: #2206 Element type is invalid

### DIFF
--- a/webpack.config.dist.js
+++ b/webpack.config.dist.js
@@ -9,7 +9,8 @@ module.exports = {
   output: {
     library: "Slider",
     libraryTarget: "umd",
-    path: path.join(__dirname, "dist")
+    path: path.join(__dirname, "dist"),
+    umdNamedDefine: true
   },
 
   module: {


### PR DESCRIPTION
allow react-slick to be bundled into a library