### PR TITLE
Update slick-theme.css

### DIFF
--- a/docs/slick-theme.css
+++ b/docs/slick-theme.css
@@ -94,7 +94,9 @@
 {
     content: '→';
 }
-
+.slick-disabled{
+    filter: grayscale(1);
+  }
 .slick-next
 {
     right: -25px;


### PR DESCRIPTION
I am having an issue where I am trying to disable the prev and next button by applying the css. But the css we are applying is not working and after having a glance at your plugin code we found that it is applied to ::before and ::after pseudo elements. we want you to update the css to apply on disbled class (without pseudo) as demonstrated below:


remove below:
.slick-prev.slick-disabled:before,
.slick-next.slick-disabled:before
{
    opacity: .25;
}

add the following:
.slick-disabled{
  filter: grayscale(1);
}
