### PR TITLE
fix: set slider wrapper key based on children keys passed

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -171,9 +171,10 @@ export default class Slider extends React.Component {
             currentWidth = children[k].props.style.width;
           }
           if (k >= children.length) break;
+          const defaultChildKey = 100 * i + 10 * j + k;
           row.push(
             React.cloneElement(children[k], {
-              key: 100 * i + 10 * j + k,
+              key: children[k].key || defaultChildKey,
               tabIndex: -1,
               style: {
                 width: `${100 / settings.slidesPerRow}%`,
@@ -182,16 +183,19 @@ export default class Slider extends React.Component {
             })
           );
         }
-        newSlide.push(<div key={10 * i + j}>{row}</div>);
+        newSlide.push(
+          <div key={row.map(child => child.key).join("")}>{row}</div>
+        );
       }
+      const key = newSlide.map(row => row.key).join("");
       if (settings.variableWidth) {
         newChildren.push(
-          <div key={i} style={{ width: currentWidth }}>
+          <div key={key} style={{ width: currentWidth }}>
             {newSlide}
           </div>
         );
       } else {
-        newChildren.push(<div key={i}>{newSlide}</div>);
+        newChildren.push(<div key={key}>{newSlide}</div>);
       }
     }
 


### PR DESCRIPTION
### Context

Currently `react-slick` does not support dynamic children, where if any of the children is updated in run time, the `react-slick` slider does not re-render accordingly. This is due to the wrapper component having it's own `key` calculation that does not take into account the children's keys that was passed.

### Solution

Utilise a combination of the children's `key` for the wrapper, this ensures that if any of the children's key updates, the wrapper knows to re-render accordingly.
