### PR TITLE
Added dotsAboveSlider prop

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -16,6 +16,7 @@ let defaultProps = {
   customPaging: i => <button>{i + 1}</button>,
   dots: false,
   dotsClass: "slick-dots",
+  dotsAboveSlider: false,
   draggable: true,
   easing: "linear",
   edgeFriction: 0.35,

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -752,6 +752,7 @@ export class InnerSlider extends React.Component {
     }
     return (
       <div {...innerSliderProps}>
+        {!this.props.unslick && this.props.dotsAboveSlider ? dots : ""}
         {!this.props.unslick ? prevArrow : ""}
         <div ref={this.listRefHandler} {...listProps}>
           <Track ref={this.trackRefHandler} {...trackProps}>
@@ -759,7 +760,7 @@ export class InnerSlider extends React.Component {
           </Track>
         </div>
         {!this.props.unslick ? nextArrow : ""}
-        {!this.props.unslick ? dots : ""}
+        {!this.props.unslick && !this.props.dotsAboveSlider ? dots : ""}
       </div>
     );
   };


### PR DESCRIPTION
Addresses [issue 2300](https://github.com/akiran/react-slick/issues/2300)

Adds new prop to determine rendering order of the dots and slider. Defaults to `false`