### PR TITLE
fix(#2017): Dots state error when SlideToshow uses decimal value and …

### DIFF
--- a/src/dots.js
+++ b/src/dots.js
@@ -2,8 +2,7 @@
 
 import React from "react";
 import classnames from "classnames";
-import { clamp } from "./utils/innerSliderUtils";
-
+import { clamp, roundToDecimal } from "./utils/innerSliderUtils";
 const getDotCount = spec => {
   let dots;
 
@@ -46,14 +45,14 @@ export class Dots extends React.PureComponent {
     const mouseEvents = { onMouseEnter, onMouseOver, onMouseLeave };
     let dots = [];
     for (let i = 0; i < dotCount; i++) {
-      let _rightBound = (i + 1) * slidesToScroll - 1;
+      let _rightBound = roundToDecimal((i + 1) * slidesToScroll - 1, 2);
       let rightBound = infinite
         ? _rightBound
         : clamp(_rightBound, 0, slideCount - 1);
-      let _leftBound = rightBound - (slidesToScroll - 1);
+      let _leftBound = roundToDecimal(rightBound - (slidesToScroll - 1), 2);
       let leftBound = infinite
         ? _leftBound
-        : clamp(_leftBound, 0, slideCount - 1);
+        : clamp(_leftBound, 0, roundToDecimal(slideCount - slidesToShow, 2));
 
       let className = classnames({
         "slick-active": infinite

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -6,10 +6,10 @@ export function clamp(number, lowerBound, upperBound) {
 
 export const safePreventDefault = event => {
   const passiveEvents = ["onTouchStart", "onTouchMove", "onWheel"];
-  if(!passiveEvents.includes(event._reactName)) {
+  if (!passiveEvents.includes(event._reactName)) {
     event.preventDefault();
   }
-}
+};
 
 export const getOnDemandLazySlides = spec => {
   let onDemandSlides = [];
@@ -386,9 +386,12 @@ export const swipeMove = (e, spec) => {
   let touchSwipeLength = touchObject.swipeLength;
   if (!infinite) {
     if (
-      (currentSlide === 0 && (swipeDirection === "right" || swipeDirection === "down")) ||
-      (currentSlide + 1 >= dotCount && (swipeDirection === "left" || swipeDirection === "up")) ||
-      (!canGoNext(spec) && (swipeDirection === "left" || swipeDirection === "up"))
+      (currentSlide === 0 &&
+        (swipeDirection === "right" || swipeDirection === "down")) ||
+      (currentSlide + 1 >= dotCount &&
+        (swipeDirection === "left" || swipeDirection === "up")) ||
+      (!canGoNext(spec) &&
+        (swipeDirection === "left" || swipeDirection === "up"))
     ) {
       touchSwipeLength = touchObject.swipeLength * edgeFriction;
       if (edgeDragged === false && onEdge) {
@@ -849,3 +852,7 @@ export const canUseDOM = () =>
     window.document &&
     window.document.createElement
   );
+export function roundToDecimal(number, decimalPlaces) {
+  const factor = Math.pow(10, decimalPlaces);
+  return Math.round(number * factor) / factor;
+}


### PR DESCRIPTION
**Issue**: #2017 

**solution**

1. Round off values in JavaScript calculations because reliability issues arise with decimal values.
2. When calculating the _leftBound_, use slidesToShow instead of 1, as the last active slide will be slideCount - slidesToShow.