### PR TITLE
feat: Add dynamic slide adjustment to multi-item carousel

### DIFF
--- a/examples/MultipleItems.js
+++ b/examples/MultipleItems.js
@@ -1,17 +1,38 @@
-import React from "react";
+import React, { useState } from "react";
 import Slider from "../src/slider";
 
 function MultipleItems() {
+  const [countOfSlides, setCountOfSlides] = useState(3);
   const settings = {
     dots: true,
     infinite: true,
     speed: 500,
-    slidesToShow: 3,
-    slidesToScroll: 3
+    slidesToShow: countOfSlides,
+    slidesToScroll: countOfSlides
   };
   return (
     <div>
       <h2> Multiple items </h2>
+      <button
+        onClick={() =>
+          countOfSlides < 9
+            ? setCountOfSlides(countOfSlides + 1)
+            : setCountOfSlides(8)
+        }
+        className="button"
+      >
+        Add slides
+      </button>
+      <button
+        onClick={() =>
+          countOfSlides > 1
+            ? setCountOfSlides(countOfSlides - 1)
+            : setCountOfSlides(1)
+        }
+        className="button"
+      >
+        Remove slides
+      </button>
       <Slider {...settings}>
         <div>
           <h3>1</h3>


### PR DESCRIPTION
**Enhancement Overview:** I have added two buttons, “Add Slides” and “Remove Slides”, to the multi-item carousel container. These buttons allow users to dynamically adjust the number of slides shown in the carousel.

**Justification:** The motivation behind this enhancement is to provide users with a more interactive experience and a clearer understanding of how the carousel behaves with different numbers of slides. By manipulating the number of slides, users can see how the carousel adjusts, providing a more tangible understanding of the slidesToShow and slidesToScroll properties.