### PR TITLE
#2320 Not able to change size of arrows of Slider #2320

### DIFF
--- a/docs/slick-theme.css
+++ b/docs/slick-theme.css
@@ -19,7 +19,7 @@
 .slick-prev,
 .slick-next
 {
-    font-size: 0;
+    font-size: 0; /* You can change this to your desired size, e.g., font-size: 24px; */
     line-height: 0;
 
     position: absolute;
@@ -27,8 +27,8 @@
 
     display: block;
 
-    width: 20px;
-    height: 20px;
+    width: 20px; /* Change this to your desired width */
+    height: 20px; /* Change this to your desired height */
     padding: 0;
     -webkit-transform: translate(0, -50%);
     -ms-transform: translate(0, -50%);
@@ -67,7 +67,7 @@
 .slick-next:before
 {
     font-family: 'slick';
-    font-size: 20px;
+    font-size: 20px; /* You can change this to your desired size */
     line-height: 1;
 
     opacity: .75;


### PR DESCRIPTION
This commit addresses styling issues related to the arrows in the React Slick slider component. The primary focus is on customizing the size of the arrows by adjusting the **font-size**, **width**, and **height** properties in the relevant CSS rules.

If the issue is not resolved please provide me more details what actually needed to solve the issue.

