### PR TITLE
2315 slick prev refresh

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -292,7 +292,9 @@ export const changeSlide = (spec, options) => {
     if (lazyLoad && !infinite) {
       targetSlide =
         ((currentSlide + slidesToScroll) % slideCount) + indexOffset;
-    } else if (!infinite) {
+    } 
+    
+    if (!infinite) {
       targetSlide = previousTargetSlide + slidesToScroll;
     }
   } else if (options.message === "dots") {

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -6,10 +6,10 @@ export function clamp(number, lowerBound, upperBound) {
 
 export const safePreventDefault = event => {
   const passiveEvents = ["onTouchStart", "onTouchMove", "onWheel"];
-  if (!passiveEvents.includes(event._reactName)) {
+  if(!passiveEvents.includes(event._reactName)) {
     event.preventDefault();
   }
-};
+}
 
 export const getOnDemandLazySlides = spec => {
   let onDemandSlides = [];
@@ -281,8 +281,7 @@ export const changeSlide = (spec, options) => {
     if (lazyLoad && !infinite) {
       previousInt = currentSlide - slideOffset;
       targetSlide = previousInt === -1 ? slideCount - 1 : previousInt;
-    } 
-    
+    }
     if (!infinite) {
       targetSlide = currentSlide - slidesToScroll;
     }
@@ -292,8 +291,7 @@ export const changeSlide = (spec, options) => {
     if (lazyLoad && !infinite) {
       targetSlide =
         ((currentSlide + slidesToScroll) % slideCount) + indexOffset;
-    } 
-    
+    }
     if (!infinite) {
       targetSlide = previousTargetSlide + slidesToScroll;
     }
@@ -388,12 +386,9 @@ export const swipeMove = (e, spec) => {
   let touchSwipeLength = touchObject.swipeLength;
   if (!infinite) {
     if (
-      (currentSlide === 0 &&
-        (swipeDirection === "right" || swipeDirection === "down")) ||
-      (currentSlide + 1 >= dotCount &&
-        (swipeDirection === "left" || swipeDirection === "up")) ||
-      (!canGoNext(spec) &&
-        (swipeDirection === "left" || swipeDirection === "up"))
+      (currentSlide === 0 && (swipeDirection === "right" || swipeDirection === "down")) ||
+      (currentSlide + 1 >= dotCount && (swipeDirection === "left" || swipeDirection === "up")) ||
+      (!canGoNext(spec) && (swipeDirection === "left" || swipeDirection === "up"))
     ) {
       touchSwipeLength = touchObject.swipeLength * edgeFriction;
       if (edgeDragged === false && onEdge) {

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -6,10 +6,10 @@ export function clamp(number, lowerBound, upperBound) {
 
 export const safePreventDefault = event => {
   const passiveEvents = ["onTouchStart", "onTouchMove", "onWheel"];
-  if(!passiveEvents.includes(event._reactName)) {
+  if (!passiveEvents.includes(event._reactName)) {
     event.preventDefault();
   }
-}
+};
 
 export const getOnDemandLazySlides = spec => {
   let onDemandSlides = [];
@@ -281,8 +281,7 @@ export const changeSlide = (spec, options) => {
     if (lazyLoad && !infinite) {
       previousInt = currentSlide - slideOffset;
       targetSlide = previousInt === -1 ? slideCount - 1 : previousInt;
-    }
-    if (!infinite) {
+    } else if (!infinite) {
       targetSlide = previousTargetSlide - slidesToScroll;
     }
   } else if (options.message === "next") {
@@ -291,8 +290,7 @@ export const changeSlide = (spec, options) => {
     if (lazyLoad && !infinite) {
       targetSlide =
         ((currentSlide + slidesToScroll) % slideCount) + indexOffset;
-    }
-    if (!infinite) {
+    } else if (!infinite) {
       targetSlide = previousTargetSlide + slidesToScroll;
     }
   } else if (options.message === "dots") {
@@ -386,9 +384,12 @@ export const swipeMove = (e, spec) => {
   let touchSwipeLength = touchObject.swipeLength;
   if (!infinite) {
     if (
-      (currentSlide === 0 && (swipeDirection === "right" || swipeDirection === "down")) ||
-      (currentSlide + 1 >= dotCount && (swipeDirection === "left" || swipeDirection === "up")) ||
-      (!canGoNext(spec) && (swipeDirection === "left" || swipeDirection === "up"))
+      (currentSlide === 0 &&
+        (swipeDirection === "right" || swipeDirection === "down")) ||
+      (currentSlide + 1 >= dotCount &&
+        (swipeDirection === "left" || swipeDirection === "up")) ||
+      (!canGoNext(spec) &&
+        (swipeDirection === "left" || swipeDirection === "up"))
     ) {
       touchSwipeLength = touchObject.swipeLength * edgeFriction;
       if (edgeDragged === false && onEdge) {

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -281,8 +281,10 @@ export const changeSlide = (spec, options) => {
     if (lazyLoad && !infinite) {
       previousInt = currentSlide - slideOffset;
       targetSlide = previousInt === -1 ? slideCount - 1 : previousInt;
-    } else if (!infinite) {
-      targetSlide = previousTargetSlide - slidesToScroll;
+    } 
+    
+    if (!infinite) {
+      targetSlide = currentSlide - slidesToScroll;
     }
   } else if (options.message === "next") {
     slideOffset = indexOffset === 0 ? slidesToScroll : indexOffset;


### PR DESCRIPTION
[#2315 ](https://github.com/akiran/react-slick/issues/2315)

After refresh the value of `previousTargetSlide` is currently resetting to 0. I replaced with the value of `currentSlide` which state value persist as same value 0f `previousTargetSlide` before refresh.

Before refresh:

![Screenshot 2024-01-22 at 10 43 47 PM](https://github.com/akiran/react-slick/assets/10134023/9e2be3ec-3e08-4704-91f6-6ee6dfe006ce)

After refresh:

<img width="914" alt="Screenshot 2024-01-22 at 11 10 00 PM" src="https://github.com/akiran/react-slick/assets/10134023/ccdc94ad-f390-4066-8ff9-d256e50c5409">
