### PR TITLE
Move testing dependency to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/preset-react": "^7.0.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
+    "@testing-library/user-event": "^14.3.0",
     "autoprefixer": "^7.1.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.8.0",
@@ -82,7 +83,6 @@
     "why-did-you-update": "^0.1.1"
   },
   "dependencies": {
-    "@testing-library/user-event": "^14.3.0",
     "classnames": "^2.2.5",
     "enquire.js": "^2.1.6",
     "json2mq": "^0.2.0",


### PR DESCRIPTION
`@testing-library/user-event` is not needed in production.