### PR TITLE
Fix for Partial Sliders with Adaptive Height Disappearance Issue

### DIFF
--- a/examples/AdaptiveHeightPartialSlider.js
+++ b/examples/AdaptiveHeightPartialSlider.js
@@ -1,0 +1,35 @@
+import React from "react";
+import Slider from "react-slick";
+
+function AdaptiveHeightPartialSlider() {
+  const settings = {
+    className: "",
+    dots: true,
+    infinite: false,
+    slidesToShow: 2.5,
+    slidesToScroll: 1,
+    adaptiveHeight: true
+  };
+
+  return (
+    <div className="slider-container">
+      <Slider {...settings}>
+        <div data-offsetheigth="10">
+          <h3>1</h3>
+          <div></div>
+        </div>
+        <div data-offsetheigth="20">
+          <h3>2</h3>
+          <p>Hello</p>
+        </div>
+        <div>
+          <h3>3</h3>
+          <p>See ....</p>
+          <p>Height is adaptive</p>
+        </div>
+      </Slider>
+    </div>
+  );
+}
+
+export default AdaptiveHeightPartialSlider;

--- a/examples/__tests__/AdaptiveHeightPartialSlider.test.js
+++ b/examples/__tests__/AdaptiveHeightPartialSlider.test.js
@@ -1,0 +1,50 @@
+import React from "react";
+
+import { render } from "@testing-library/react";
+import { clickNext } from "../../test-utils";
+import AdaptiveHeightPartialSlider from "../AdaptiveHeightPartialSlider";
+
+const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "offsetHeight"
+);
+
+const mockOffsetHeight = {
+  configurable: true,
+  get() {
+    return this.firstChild.firstChild.dataset.offsetheigth || -1;
+  }
+};
+
+describe("AdaptiveHeightPartialSlider", () => {
+  beforeAll(() => {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "offsetHeight",
+      mockOffsetHeight
+    );
+  });
+
+  afterAll(() => {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "offsetHeight",
+      originalOffsetHeight
+    );
+  });
+
+  test("Renders the AdaptiveHeightPartialSlider component with initial height of 10px for the first slide", () => {
+    const { container } = render(<AdaptiveHeightPartialSlider />);
+    expect(container.querySelector(".slick-list")).toHaveStyle({
+      height: "10px"
+    });
+  });
+
+  test("Changes the height to 20px for the second slide after clicking next", () => {
+    const { container } = render(<AdaptiveHeightPartialSlider />);
+    clickNext(container);
+    expect(container.querySelector(".slick-list")).toHaveStyle({
+      height: "20px"
+    });
+  });
+});

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -48,9 +48,7 @@ export class InnerSlider extends React.Component {
   trackRefHandler = ref => (this.track = ref);
   adaptHeight = () => {
     if (this.props.adaptiveHeight && this.list) {
-      const elem = this.list.querySelector(
-        `[data-index="${this.state.currentSlide}"]`
-      );
+      const elem = this.list.querySelector(".slick-current");
       this.list.style.height = getHeight(elem) + "px";
     }
   };


### PR DESCRIPTION
## Description:

This pull request addresses the issue where sliders disappear when attempting to display a partial number of sliders with the `adaptiveHeight` property set to `true`. The implemented solution involves considering the slider with the `slick-current` classname as the current slider.


## Changes made:

✅  Modified the height calculation to consider the slider marked as `slick-current` as the current one.
✅  Added a test that ensures partial sliders with adaptive height are displayed correctly.

## Demonstrations:

- Attached is a video demonstrating the issue before applying the fix.

https://github.com/akiran/react-slick/assets/16759154/2fd4d9aa-84ef-4300-a714-8a38cd8eb941

- Another video is attached showing the functionality after implementing the solution:


https://github.com/akiran/react-slick/assets/16759154/9665496e-0dbd-410e-9dc3-bf2a7420dcc0


## How to Test the Changes:

1. Add an odd number of sliders greater than the unit, for example 3 slides.
2. In the settings, indicate that you only want to show with `slidesToShow` 2.5 slides, which would be 2 sliders and partially the next one. The `centerMode` and `infinite` field must be disabled.
3. Drag to the left slider to check that they are partially displayed.

## Additional Notes:

👍 Checked that the other tests work perfectly
👍 Checked if the change of getting the current slider with `slider-current` affects other part of the project