### PR TITLE
Use `focusOnChange` where appropriate

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -436,7 +436,7 @@ export class InnerSlider extends React.Component {
       this.slideHandler(targetSlide);
     }
     this.props.autoplay && this.autoPlay("update");
-    if (this.props.focusOnSelect) {
+    if (this.props.focusOnChange) {
       const nodes = this.list.querySelectorAll(".slick-current");
       nodes[0] && nodes[0].focus();
     }
@@ -627,7 +627,7 @@ export class InnerSlider extends React.Component {
       "speed",
       "infinite",
       "centerMode",
-      "focusOnSelect",
+      "focusOnChange",
       "currentSlide",
       "lazyLoad",
       "lazyLoadedList",
@@ -652,8 +652,7 @@ export class InnerSlider extends React.Component {
       onMouseEnter: pauseOnHover ? this.onTrackOver : null,
       onMouseLeave: pauseOnHover ? this.onTrackLeave : null,
       onMouseOver: pauseOnHover ? this.onTrackOver : null,
-      focusOnSelect:
-        this.props.focusOnSelect && this.clickable ? this.selectHandler : null
+      focusOnChange: this.props.focusOnChange ? this.focusOnChange : null
     };
 
     var dots;


### PR DESCRIPTION
Fixes [#1935](https://github.com/akiran/react-slick/issues/1935)

In slick-carousel version 1.8.0 a feature was added called `focusOnChange` which made the behavior previously bundled into `focusOnSelect` more specialized. See https://github.com/kenwheeler/slick/pull/3032.

Based on the behavior it is being used for in react-slick, this is a more accurate prop to use for this behavior.