### PR TITLE
[Bug]: unslick is missing in filterSettings

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -51,7 +51,8 @@ let defaultProps = {
   variableWidth: false,
   vertical: false,
   waitForAnimate: true,
-  asNavFor: null
+  asNavFor: null,
+  unslick: false
 };
 
 export default defaultProps;


### PR DESCRIPTION
The unslick property is missing in the filterSettings, so the value of unslick inside InnerSlider is always undefined

