### PR TITLE
fix: add the missing default prop for verticalSwiping

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -49,6 +49,7 @@ let defaultProps = {
   useCSS: true,
   useTransform: true,
   variableWidth: false,
+  verticalSwiping: false,
   vertical: false,
   waitForAnimate: true,
   asNavFor: null,


### PR DESCRIPTION
## Description:
This PR addresses an issue where the verticalSwiping prop was missing a default value, which impacted the filtering of component settings before passing them to the inner slider component. By adding the missing default prop, we ensure that verticalSwiping has a consistent value, preventing potential errors or inconsistent behavior.

## Changes:
- Added a default value for the verticalSwiping prop to ensure that it is not filtered out before being passed to the inner slider component.

## Why this is necessary:
The absence of a default value for `verticalSwiping` caused the inner slider to behave incorrectly and led to unexpected behavior while swiping vertically in vertical mode.
