### PR TITLE
Fix: vertical swiping does not work

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -50,6 +50,7 @@ let defaultProps = {
   useTransform: true,
   variableWidth: false,
   vertical: false,
+  verticalSwiping: false,
   waitForAnimate: true,
   asNavFor: null,
   unslick: false


### PR DESCRIPTION
Fixed: the Setting props `verticalSwiping` does not work

In the VertialMode demo, touch swiping up or down, there is no reaction of it.