### PR TITLE
Feat: added tabindex logic for better accessibility support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slick",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oggo-petersen/react-slick",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-slick",
-  "version": "0.30.4",
+  "name": "@oggo-petersen/react-slick",
+  "version": "0.30.6",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-slick",
+  "name": "@oggo-petersen/react-slick",
   "version": "0.30.4",
   "description": " React port of slick carousel",
   "main": "./lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@oggo-petersen/react-slick",
-  "version": "0.30.6",
+  "name": "react-slick",
+  "version": "0.30.4",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@oggo-petersen/react-slick",
-  "version": "0.30.5",
+  "name": "react-slick",
+  "version": "0.30.4",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/src/slider.js
+++ b/src/slider.js
@@ -26,7 +26,7 @@ export default class Slider extends React.Component {
     this.observer = new IntersectionObserver(
       entries => {
         entries.forEach(entry => {
-          entry.target.tabIndex = entry.isIntersecting ? 1 : -1;
+          entry.target.tabIndex = entry.isIntersecting ? 0 : -1;
         });
       },
       {

--- a/src/slider.js
+++ b/src/slider.js
@@ -13,9 +13,33 @@ export default class Slider extends React.Component {
       breakpoint: null
     };
     this._responsiveMediaHandlers = [];
+    this.childRefs = new Set();
+    this.observer = null;
   }
 
   innerSliderRefHandler = ref => (this.innerSlider = ref);
+
+  setupIntersectObserver() {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+    this.observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          entry.target.tabIndex = entry.isIntersecting ? 1 : -1;
+        });
+      },
+      {
+        root: null,
+        threshold: 0.1
+      }
+    );
+    this.childRefs.forEach(element => {
+      if (element) {
+        this.observer.observe(element);
+      }
+    });
+  }
 
   media(query, handler) {
     // javascript handler for  css media query
@@ -31,6 +55,9 @@ export default class Slider extends React.Component {
 
   // handles responsive breakpoints
   componentDidMount() {
+    window.addEventListener("resize", this.setupIntersectionObserver);
+    window.addEventListener("scroll", this.setupIntersectionObserver);
+    setTimeout(() => this.setupIntersectObserver(), 0);
     // performance monitoring
     //if (process.env.NODE_ENV !== 'production') {
     //const { whyDidYouUpdate } = require('why-did-you-update')
@@ -76,6 +103,8 @@ export default class Slider extends React.Component {
     this._responsiveMediaHandlers.forEach(function(obj) {
       obj.mql.removeListener(obj.listener);
     });
+    window.removeEventListener("resize", this.setupIntersectionObserver);
+    window.removeEventListener("scroll", this.setupIntersectionObserver);
   }
 
   slickPrev = () => this.innerSlider.slickPrev();
@@ -179,7 +208,11 @@ export default class Slider extends React.Component {
           row.push(
             React.cloneElement(children[k], {
               key: 100 * i + 10 * j + k,
-              tabIndex: -1,
+              ref: el => {
+                if (el) {
+                  this.childRefs.add(el);
+                }
+              },
               style: {
                 width: `${100 / settings.slidesPerRow}%`,
                 display: "inline-block"

--- a/src/slider.js
+++ b/src/slider.js
@@ -27,6 +27,10 @@ export default class Slider extends React.Component {
       entries => {
         entries.forEach(entry => {
           entry.target.tabIndex = entry.isIntersecting ? 0 : -1;
+          entry.target.setAttribute(
+            "aria-hidden",
+            entry.isIntersecting ? "false" : "true"
+          );
         });
       },
       {

--- a/src/slider.js
+++ b/src/slider.js
@@ -35,7 +35,7 @@ export default class Slider extends React.Component {
       }
     );
     this.childRefs.forEach(element => {
-      if (element) {
+      if (element && element instanceof Element) {
         this.observer.observe(element);
       }
     });

--- a/src/track.js
+++ b/src/track.js
@@ -123,9 +123,13 @@ const renderSlides = spec => {
         key: "original" + getKey(child, index),
         "data-index": index,
         className: classnames(slideClasses, slideClass),
-        tabIndex: "-1",
+        tabIndex: !slideClasses["slick-active"] ? "-1" : "1",
         "aria-hidden": !slideClasses["slick-active"],
-        style: { outline: "none", ...(child.props.style || {}), ...childStyle },
+        style: {
+          outline: "none",
+          ...(child.props.style || {}),
+          ...childStyle
+        },
         onClick: e => {
           child.props && child.props.onClick && child.props.onClick(e);
           if (spec.focusOnSelect) {
@@ -153,7 +157,7 @@ const renderSlides = spec => {
           React.cloneElement(child, {
             key: "precloned" + getKey(child, key),
             "data-index": key,
-            tabIndex: "-1",
+            tabIndex: !slideClasses["slick-active"] ? "-1" : "1",
             className: classnames(slideClasses, slideClass),
             "aria-hidden": !slideClasses["slick-active"],
             style: { ...(child.props.style || {}), ...childStyle },
@@ -176,7 +180,7 @@ const renderSlides = spec => {
         React.cloneElement(child, {
           key: "postcloned" + getKey(child, key),
           "data-index": key,
-          tabIndex: "-1",
+          tabIndex: !slideClasses["slick-active"] ? "-1" : "1",
           className: classnames(slideClasses, slideClass),
           "aria-hidden": !slideClasses["slick-active"],
           style: { ...(child.props.style || {}), ...childStyle },

--- a/src/track.js
+++ b/src/track.js
@@ -129,7 +129,6 @@ const renderSlides = spec => {
           }
         },
         className: classnames(slideClasses, slideClass),
-        "aria-hidden": !slideClasses["slick-active"],
         style: {
           outline: "none",
           ...(child.props.style || {}),
@@ -185,7 +184,6 @@ const renderSlides = spec => {
           key: "postcloned" + getKey(child, key),
           "data-index": key,
           className: classnames(slideClasses, slideClass),
-          "aria-hidden": !slideClasses["slick-active"],
           style: { ...(child.props.style || {}), ...childStyle },
           onClick: e => {
             child.props && child.props.onClick && child.props.onClick(e);
@@ -237,6 +235,10 @@ export class Track extends React.PureComponent {
       entries => {
         entries.forEach(entry => {
           entry.target.tabIndex = entry.isIntersecting ? 0 : -1;
+          entry.target.setAttribute(
+            "aria-hidden",
+            entry.isIntersecting ? "false" : "true"
+          );
         });
       },
       {

--- a/src/track.js
+++ b/src/track.js
@@ -161,8 +161,12 @@ const renderSlides = spec => {
           React.cloneElement(child, {
             key: "precloned" + getKey(child, key),
             "data-index": key,
+            ref: el => {
+              if (el) {
+                childRefs.add(el);
+              }
+            },
             className: classnames(slideClasses, slideClass),
-            "aria-hidden": !slideClasses["slick-active"],
             style: { ...(child.props.style || {}), ...childStyle },
             onClick: e => {
               child.props && child.props.onClick && child.props.onClick(e);
@@ -183,6 +187,11 @@ const renderSlides = spec => {
         React.cloneElement(child, {
           key: "postcloned" + getKey(child, key),
           "data-index": key,
+          ref: el => {
+            if (el) {
+              childRefs.add(el);
+            }
+          },
           className: classnames(slideClasses, slideClass),
           style: { ...(child.props.style || {}), ...childStyle },
           onClick: e => {


### PR DESCRIPTION
This PR aims to add `tabIndex` support for better accessibility, since all `tabIndex` inside the project are always set to `-1`.

The main solution consists into:

## src/track.js
Added the correct `tabIndex` based on the class `slick-active`

## src/slider.js
This one was a little bit more complex to add the support, so I went with the `IntersectionObserver`, which will add to the element itself the correct `tabIndex`.
We also use a list of refs to add the observer correctly to the elements rendered.