### PR TITLE
chore: add download count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### react-slick
 
-[![Backers on Open Collective](https://opencollective.com/react-slick/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/react-slick/sponsors/badge.svg)](#sponsors)
+[![Backers on Open Collective](https://opencollective.com/react-slick/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/react-slick/sponsors/badge.svg)](#sponsors) [![npm downloads](https://npm-compare.com/react-slick/#timeRange=FIVE_YEARS)
 
 ##### Carousel component built with React. It is a react port of [slick carousel](http://kenwheeler.github.io/slick/)
 


### PR DESCRIPTION
Hi,

I’ve added a new NPM download trend badge to the [react-slick](https://npm-compare.com/react-slick/#timeRange=FIVE_YEARS) README. This badge links to a dynamic chart on npm-compare.com that displays the download trends for react-slick over the past five years. It provides a visual representation of the package's growth and can help new users better understand its popularity and adoption.

Added badge: [![npm downloads](https://badgen.net/npm/dw/react-slick)](https://npm-compare.com/react-slick/#timeRange=FIVE_YEARS)

This badge links to a 5-year trend chart on npm-compare.com, showing the package's download history. This gives users insight into how well react-slick has been adopted over time, which can increase confidence in using it.

As a maintainer of npm-compare.com, I’m happy to assist with any additional features or insights from our site if needed. Thanks for considering my suggestion!
