### PR TITLE
Check current viewport against responsive settings on initial load (fixes #2439)

### DIFF
--- a/playwright-tests/features/responsive/responsive.spec.tsx
+++ b/playwright-tests/features/responsive/responsive.spec.tsx
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/experimental-ct-react";
 import Responsive from "./responsive.story";
 
-test.use({ viewport: { width: 1200, height: 500 } });
+test.use({ viewport: { width: 1000, height: 500 } });
 
 async function activeSlidesCount(component) {
   return await component.locator(".slick-slide.slick-active").count();
@@ -10,11 +10,11 @@ async function activeSlidesCount(component) {
 test("Responsive settings", async ({ mount, page }) => {
   const component = await mount(<Responsive />);
 
-  await expect(await activeSlidesCount(component)).toEqual(4);
-
-  await page.setViewportSize({ width: 1000, height: 500 });
-  await page.waitForTimeout(100);
   await expect(await activeSlidesCount(component)).toEqual(3);
+
+  await page.setViewportSize({ width: 1200, height: 500 });
+  await page.waitForTimeout(100);
+  await expect(await activeSlidesCount(component)).toEqual(4);
 
   await page.setViewportSize({ width: 600, height: 500 });
   await page.waitForTimeout(100);

--- a/src/slider.js
+++ b/src/slider.js
@@ -26,6 +26,12 @@ export default class Slider extends React.Component {
       }
     };
     mql.addListener(listener);
+
+    // Manually check if the query currently matches on initial load
+    if (mql.matches) {
+      handler();
+    }
+
     this._responsiveMediaHandlers.push({ mql, query, listener });
   }
 


### PR DESCRIPTION
This PR adds a manual check against the responsive query when the `Slider` component initially loads. This will make sure the `Slider` pulls in any related responsive settings based on the current viewport when it first renders. The `responsive.spec.tsx` test for playwright was also updated to catch this edge case. It's initial viewport is now one that hits a responsive breakpoint instead of the default. This fixes issue #2439